### PR TITLE
Replace for const... with let for Firefox compat

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,5 @@ rules:
   no-var: 1
   no-warning-comments: [1, {terms: [xxx, fixme, hack], location: start}]
   object-shorthand: [2, properties]
-  prefer-const: 1
   guard-for-in: 1  # There's nothing wrong with for..in if you know what you're doing. This is here just to keep me from accidentally saying "for..in" when I mean "for..of". Delete this and come up with a better solution if we ever need to use "for..in".
   no-throw-literal: 2

--- a/index.js
+++ b/index.js
@@ -45,9 +45,9 @@ function ruleset(...rules) {
             // digested. Rules run in no particular guaranteed order.
             while (nonterminals.length) {
                 const [inNode, inFlavor] = nonterminals.pop();
-                for (const rule of getDefault(rulesByInputFlavor, inFlavor, () => [])) {
+                for (let rule of getDefault(rulesByInputFlavor, inFlavor, () => [])) {
                     const outFacts = resultsOf(rule, inNode, inFlavor, kb);
-                    for (const fact of outFacts) {
+                    for (let fact of outFacts) {
                         const outNode = kb.nodeForElement(fact.element);
 
                         // No matter whether or not this flavor has been
@@ -167,9 +167,9 @@ function *resultsOfDomRule(rule, specialDomNode, kb) {
     // Use the special "tree" property of the special starting node:
     const matches = specialDomNode.tree.querySelectorAll(rule.source.selector);
 
-    for (const element of matches) {
+    for (let element of matches) {
         const newFacts = explicitFacts(rule.ranker(kb.nodeForElement(element)));
-        for (const fact of newFacts) {
+        for (let fact of newFacts) {
             if (fact.element === undefined) {
                 fact.element = element;
             }
@@ -185,7 +185,7 @@ function *resultsOfDomRule(rule, specialDomNode, kb) {
 function *resultsOfFlavorRule(rule, node, flavor) {
     const newFacts = explicitFacts(rule.ranker(node));
 
-    for (const fact of newFacts) {
+    for (let fact of newFacts) {
         // If the ranker didn't specify a different element, assume it's
         // talking about the one we passed in:
         if (fact.element === undefined) {
@@ -206,7 +206,7 @@ function *resultsOfFlavorRule(rule, node, flavor) {
 // array of facts.
 function *explicitFacts(rankerResult) {
     const array = (rankerResult === undefined) ? [] : (Array.isArray(rankerResult) ? rankerResult : [rankerResult]);
-    for (const fact of array) {
+    for (let fact of array) {
         if (fact.score === undefined) {
             fact.score = 1;
         }

--- a/utils.js
+++ b/utils.js
@@ -65,7 +65,7 @@ function sum(iterable) {
 
 function length(iterable) {
     let num = 0;
-    for (const item of iterable) {
+    for (let item of iterable) {
         num++;
     }
     return num;
@@ -77,9 +77,9 @@ function length(iterable) {
 //     and its children
 function *walk(element, shouldTraverse) {
     yield element;
-    for (const child of element.childNodes) {
+    for (let child of element.childNodes) {
         if (shouldTraverse(child)) {
-            for (const w of walk(child, shouldTraverse)) {
+            for (let w of walk(child, shouldTraverse)) {
                 yield w;
             }
         }
@@ -109,7 +109,7 @@ function isBlock(element) {
 function *inlineTexts(element, shouldTraverse = element => true) {
     // TODO: Could we just use querySelectorAll() with a really long
     // selector rather than walk(), for speed?
-    for (const child of walk(element,
+    for (let child of walk(element,
                              element => !(isBlock(element) ||
                                           element.tagName === 'SCRIPT' &&
                                           element.tagName === 'STYLE')
@@ -305,9 +305,9 @@ class DistanceMatrix {
         const clusters = elements.map(el => [el]);
 
         // Init matrix:
-        for (const outerCluster of clusters) {
+        for (let outerCluster of clusters) {
             const innerMap = new Map();
-            for (const innerCluster of this._matrix.keys()) {
+            for (let innerCluster of this._matrix.keys()) {
                 innerMap.set(innerCluster, distance(outerCluster[0],
                                                     innerCluster[0]));
             }
@@ -327,8 +327,8 @@ class DistanceMatrix {
 
         // Return the distances between every pair of clusters.
         function *clustersAndDistances() {
-            for (const [outerKey, row] of self._matrix.entries()) {
-                for (const [innerKey, storedDistance] of row.entries()) {
+            for (let [outerKey, row] of self._matrix.entries()) {
+                for (let [innerKey, storedDistance] of row.entries()) {
                     yield {a: outerKey, b: innerKey, distance: storedDistance};
                 }
             }
@@ -373,7 +373,7 @@ class DistanceMatrix {
         // There will be no repetition in the matrix because, after all,
         // nothing pointed to this new cluster before it existed.
         const newRow = new Map();
-        for (const outerKey of this._matrix.keys()) {
+        for (let outerKey of this._matrix.keys()) {
             if (outerKey !== clusterA && outerKey !== clusterB) {
                 newRow.set(outerKey, Math.min(this._cachedDistance(clusterA, outerKey),
                                               this._cachedDistance(clusterB, outerKey)));
@@ -385,7 +385,7 @@ class DistanceMatrix {
         this._matrix.delete(clusterB);
 
         // Remove inner refs to the clusters we're merging.
-        for (const inner of this._matrix.values()) {
+        for (let inner of this._matrix.values()) {
             inner.delete(clusterA);
             inner.delete(clusterB);
         }


### PR DESCRIPTION
Despite `for (const blah of whatever)` being perfectly legal according to spec, Firefox throws a syntax error. Sucky

This looks like it might be the bug? https://bugzilla.mozilla.org/show_bug.cgi?id=1094995
