### PR TITLE
Add coveralls badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fathom
 
 [![Build Status](https://travis-ci.org/mozilla/fathom.svg?branch=master)](https://travis-ci.org/mozilla/fathom)
+[![Coverage Status](https://coveralls.io/repos/github/mozilla/fathom/badge.svg?branch=master)](https://coveralls.io/github/mozilla/fathom?branch=master)
 
 Find meaning in the web.
 


### PR DESCRIPTION
I enabled coveralls support for the repo, and this adds the badger to the README, but I still need to figure out how to submit the coverage info from each Travis-CI PR to the coveralls system.