### PR TITLE
Allow running rulesets against elements as well as documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,14 @@ textContainer fnodes emitted        assign "countedWords" type
 
 Remember that Fathom's rulesets are unordered, so any rule's output can flow into any other rule, not just ones that happen to come lexically after it.
 
-Once the ruleset is defined, run a DOM tree through it:
+Once the ruleset is defined, run a DOM tree or a subtree through it:
 
 ```javascript
+var myDom = jsdom.jsdom("<html><head>...</html>"));
 // Tell the ruleset which DOM to run against, yielding a factbase about the document.
-var facts = rules.against(jsdom.jsdom("<html><head>...</html>"));
+var facts = rules.against(myDom);
+// Or we can apply the ruleset to a subtree rooted at some element instead.
+var subtreeFacts = rules.against(myDom.body.firstElementChild);
 ```
 
 Then, pull the answers out of the factbase: in this case, we want the max-scoring title, which the ruleset conveniently stores under the "title" output key:

--- a/test/ruleset_tests.js
+++ b/test/ruleset_tests.js
@@ -193,6 +193,29 @@ describe('Ruleset', function () {
         assert.equal(boths.length, 1);
         assert.deepEqual(Array.from(boths[0].typesSoFar()), ['C', 'A', 'BOTH']);  // no NEEDLESS was run
     });
+
+    it('takes a subtree of a document and operates on it', function () {
+        const doc = jsdom(`
+            <div id=root>some text
+             <div id=inner>some more text</div>
+            </div>
+        `);
+        const rules = ruleset(
+            rule(dom('#root'), type('smoo').score(10)),
+            rule(dom('#inner'), type('smoo').score(5)),
+            rule(type('smoo').max(), out('best'))
+        );
+        const facts = rules.against(doc);
+        const best = facts.get('best');
+        assert.equal(best.length, 1);
+        assert.equal(best[0].element.id, 'root');
+
+        const subtree = doc.getElementById('root');
+        const subtreeFacts = rules.against(subtree);
+        const subtreeBest = subtreeFacts.get('best');
+        assert.equal(subtreeBest.length, 1);
+        assert.equal(subtreeBest[0].element.id, 'inner');
+    });
 });
 
 describe('Rule', function () {


### PR DESCRIPTION
I'd like to be able to run a fathom ruleset on a subtree of the DOM (i.e. rooted at some element in the DOM, rather than on the entire DOM). Seeing as the only thing fathom needs is a querySelectorAll, which is available on Element as well as Document, it can trivially allow this.