### PR TITLE
Add rollup config for creating a single-file build of Fathom.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.log
 /coverage
 /docs/_build
+/dist

--- a/index.js
+++ b/index.js
@@ -7,11 +7,14 @@ const {ruleset} = require('./ruleset');
 const {dom} = require('./lhs');
 const {out} = require('./rhs');
 const {and, atMost, conserveScore, max, note, props, score, type, typeIn} = require('./side');
+const utils = require('./utils');
+const clusters = require('./clusters');
 
 
 module.exports = {
     and,
     atMost,
+    clusters,
     conserveScore,
     dom,
     max,
@@ -22,5 +25,6 @@ module.exports = {
     ruleset,
     score,
     type,
-    typeIn
+    typeIn,
+    utils,
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "istanbul": "^0.4.5",
     "jsdom": "^11.2.0",
     "leven": "^2.1.0",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "rollup": "^0.50.0",
+    "rollup-plugin-commonjs": "^8.2.4",
+    "rollup-plugin-node-resolve": "^3.0.0"
   },
   "engines": {
     "node": ">= 6.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default {
+  input: 'index.js',
+  name: 'fathom',
+  output: {
+    file: 'dist/fathom.js',
+    format: 'umd',
+  },
+  plugins: [
+    resolve({
+      jsnext: true,
+      main: true
+    }),
+    commonjs({
+      include: ['node_modules/**', './*'],
+    }),
+  ],
+};


### PR DESCRIPTION
I wanted to use fathom in a webextension, but didn't want to bother setting up webpack or another module bundler. So I threw together a quick [Rollup](https://rollupjs.org/) config to build a single `fathom.js` file using UMD. When dropped in a webpage, it should add a `fathom` global with all the exports from the library on it. After installing the dev dependencies, you can run it with `./node_modules/.bin/rollup -c`.

I made a minor attempt at seeing if I could run the test suite against it, and failed; mocha seems to error out with the message: `Cannot read property 'regeneratorRuntime' of undefined`, referring to a reference to `global.regeneratorRuntime`. I think it has something to do with how [wu.js](https://github.com/fitzgen/wu.js/) is Webpacked, but I'm not really sure.

I tested this using the example from the [Basic Use docs](https://mozilla.github.io/fathom/using.html) and it seems to work. 

I doubt this is ready for merging and needs work to be reliable and usable, but I figured sharing it was better than not.