### PR TITLE
Adds commandline tool to list filenames for vectorization and optionally save to a file

### DIFF
--- a/cli/fathom_web/list.py
+++ b/cli/fathom_web/list.py
@@ -1,18 +1,19 @@
-from click import argument, command, File, option, Path
 import pathlib
+
+from click import argument, command, File, option, Path
 
 
 @command()
-@option('--out_file', '-o', type=File(mode='w'), default=None,
+@option('--out-file', '-o', type=File(mode='w'), default=None,
         help='A file for saving the printed filenames for easy future reference.')
-@argument('in_directory', type=Path(exists=True, file_okay=False, allow_dash=True))
+@argument('in_directory', type=Path(exists=True, file_okay=False))
 def main(in_directory, out_file):
     """
     Lists filenames in a IN_DIRECTORY, one filename per line. Optionally saves output to OUT_FILE.
 
     Ignores hidden files.
 
-    This is useful for vectorizing samples using fathom-fox. Fathom-fox expects input filenames copied into a text box
+    This is useful for vectorizing samples using FathomFox. FathomFox expects input filenames copied into a text box
     with one filename per line.
     """
     if out_file is not None:

--- a/cli/fathom_web/list.py
+++ b/cli/fathom_web/list.py
@@ -1,0 +1,32 @@
+from click import argument, command, File, option, Path
+import pathlib
+
+
+@command()
+@option('--out_file', '-o', type=File(mode='w'), default=None,
+        help='A file for saving the printed filenames for easy future reference.')
+@argument('in_directory', type=Path(exists=True, file_okay=False, allow_dash=True))
+def main(in_directory, out_file):
+    """
+    Lists filenames in a IN_DIRECTORY, one filename per line. Optionally saves output to OUT_FILE.
+
+    Ignores hidden files.
+
+    This is useful for vectorizing samples using fathom-fox. Fathom-fox expects input filenames copied into a text box
+    with one filename per line.
+    """
+    if out_file is not None:
+        filenames_to_save = []
+
+    for file in pathlib.Path(in_directory).iterdir():
+        # Ignore hidden files
+        if file.name.startswith('.'):
+            continue
+
+        print(file.name)
+
+        if out_file is not None:
+            filenames_to_save.append(file.name + '\n')
+
+    if out_file is not None:
+        out_file.writelines(filenames_to_save)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -16,7 +16,8 @@ setup(
     entry_points={'console_scripts': [
         'fathom-train = fathom_web.train:main',
         'fathom-unzip = fathom_web.unzip:main',
-        'fathom-pick = fathom_web.pick:main'
+        'fathom-pick = fathom_web.pick:main',
+        'fathom-list = fathom_web.list:main'
     ]},
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Addresses #97 

This PR adds a command line tool to aid in vectorization. You can list the files in a directory for easy copy-pasting into the vectorizer box in Fathom-Fox. Optionally, you can save the output to a file so you can reference the file later and forgo using this tool every time.