### PR TITLE
Fix #118: Improve `isVisible` for correctness and performance

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -37,6 +37,7 @@ rules:
   no-var: warn
   no-warning-comments: [warn, {terms: [xxx, fixme, hack], location: start}]
   object-shorthand: [error, properties]
+  operator-linebreak: [error, after]
   prefer-const: off
   quotes: [error, single, {avoidEscape: true, allowTemplateLiterals: true}]
   semi: [error, always]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -37,7 +37,6 @@ rules:
   no-var: warn
   no-warning-comments: [warn, {terms: [xxx, fixme, hack], location: start}]
   object-shorthand: [error, properties]
-  operator-linebreak: [error, after]
   prefer-const: off
   quotes: [error, single, {avoidEscape: true, allowTemplateLiterals: true}]
   semi: [error, always]

--- a/test/demos.mjs
+++ b/test/demos.mjs
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 
-import {dom, out, rule, ruleset, type} from '../index';
+import {dom, rule, ruleset, type} from '../index';
 import {sigmoid, staticDom} from '../utils';
 
 

--- a/test/lhs_tests.mjs
+++ b/test/lhs_tests.mjs
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 
-import {dom, rule, ruleset, out, type} from '../index';
+import {dom, rule, ruleset, type} from '../index';
 import {staticDom} from '../utils';
 
 

--- a/test/ruleset_tests.mjs
+++ b/test/ruleset_tests.mjs
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 
 import {distance} from '../clusters';
-import {and, dom, nearest, out, props, rule, ruleset, score, type} from '../index';
+import {and, dom, nearest, props, rule, ruleset, score, type} from '../index';
 import {domSort, sigmoid, staticDom} from '../utils';
 
 

--- a/test/utils_tests.mjs
+++ b/test/utils_tests.mjs
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {dom, out, rule, ruleset, score, type} from '../index';
+import {dom, rule, ruleset, score, type} from '../index';
 import {NiceSet, toposort, staticDom, attributesMatch} from '../utils';
 
 

--- a/utilsForFrontend.mjs
+++ b/utilsForFrontend.mjs
@@ -460,11 +460,9 @@ export function sigmoid(x) {
 /**
  * Return whether an element is practically visible, considering things like 0
  * size or opacity, ``visibility: hidden`` and ``overflow: hidden``.
- *
- * This could be 5x more efficient if https://github.com/w3c/csswg-drafts/issues/4122
- * happens.
  */
 export function isVisible(fnodeOrElement) {
+    // This could be 5x more efficient if https://github.com/w3c/csswg-drafts/issues/4122 happens.
     const element = toDomElement(fnodeOrElement);
     // Avoid reading ``display: none`` due to Bug 1381071
     const elementRect = element.getBoundingClientRect();
@@ -475,7 +473,14 @@ export function isVisible(fnodeOrElement) {
     if (elementStyle.visibility === 'hidden') {
         return false;
     }
+    // Check if the element is off-screen
     const frame = element.ownerDocument.defaultView;
+    if (elementRect.x + elementRect.width < 0
+        || (elementRect.y + elementRect.height) < 0
+        || (elementRect.x > frame.innerWidth || elementRect.y > frame.innerHeight)
+    ) {
+        return false;
+    }
     for (const ancestor of ancestors(element)) {
         const isElement = ancestor === element;
         const style = isElement ? elementStyle : getComputedStyle(ancestor);
@@ -491,10 +496,6 @@ export function isVisible(fnodeOrElement) {
         if ((rect.width === 0 || rect.height === 0) && elementStyle.overflow === 'hidden') {
             // Zero-sized ancestors don’t make descendants hidden unless the descendant
             // has overflow: hidden
-            return false;
-        }
-        // Check if the element is off-screen
-        if (isElement && ((rect.right + frame.scrollX < 0) || (rect.bottom + frame.scrollY < 0))) {
             return false;
         }
     }

--- a/utilsForFrontend.mjs
+++ b/utilsForFrontend.mjs
@@ -160,8 +160,8 @@ export function *inlineTexts(element, shouldTraverse = element => true) {
     for (let child of walk(element,
                            element => !(isBlock(element) ||
                                         element.tagName === 'SCRIPT' &&
-                                        element.tagName === 'STYLE') &&
-                                        shouldTraverse(element))) {
+                                        element.tagName === 'STYLE')
+                                      && shouldTraverse(element))) {
         if (child.nodeType === child.TEXT_NODE) {
             // wholeText() is not implemented by jsdom, so we use
             // textContent(). The result should be the same, since

--- a/utilsForFrontend.mjs
+++ b/utilsForFrontend.mjs
@@ -468,8 +468,8 @@ export function isVisible(fnodeOrElement) {
         if (style.visibility === 'hidden' ||
             style.display === 'none' ||
             style.opacity === '0' ||
-            style.width === '0' ||
-            style.height === '0') {
+            style.width === '0px' ||
+            style.height === '0px') {
             return false;
         } else {
             // It wasn't hidden based on a computed style. See if it's


### PR DESCRIPTION
The width and height properties in the return value from getComputedStyle are of the form '*px'.