### PR TITLE
Out rule simplification

### DIFF
--- a/docs/ruleset.rst
+++ b/docs/ruleset.rst
@@ -91,6 +91,8 @@ A good practice is to use more declarative calls—:func:`score`, :func:`note`, 
 
 .. autofunction:: out
 
+   If you are not using ``through()`` or ``allThrough()``, you can omit the call to ``out()`` and simply use specify the key as the RHS of the rule. For example: ``rule(type('titley').max(), out('title'))`` can be written as ``rule(type('titley').max(), 'title')``.
+
    .. autofunction:: OutwardRhs#through
       :short-name:
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -57,7 +57,7 @@ This simple ruleset finds DOM nodes that could contain a useful page title and s
            // The score on that node will represent the probability, informed by a
            // corpus of training pages, that the node is, indeed, the proper page
            // title.
-           rule(type('titley').max(), out('title'))
+           rule(type('titley').max(), 'title')
        ],
        [['colons', -0.3606211543083191], ['length', -1.6875461339950562]],  // coefficients from training
        ['titley', 3.660104751586914]  // biases from training

--- a/rule.mjs
+++ b/rule.mjs
@@ -1,7 +1,7 @@
 import wu from 'wu';
 
 import {Fnode} from './fnode';
-import {OutwardRhs} from './rhs';
+import {out, OutwardRhs} from './rhs';
 import {NiceSet, setDefault} from './utilsForFrontend';
 import {identity} from './utilsForFrontend';
 
@@ -24,6 +24,9 @@ export function rule(lhs, rhs, options) {
     // a shortcut here: any outward RHS will already be an OutwardRhs; we don't
     // need to sidetrack it through being a Side. And OutwardRhs has an asRhs()
     // that just returns itself.
+    if (typeof rhs === 'string') {
+        rhs = out(rhs);
+    }
     return new ((rhs instanceof OutwardRhs) ? OutwardRule : InwardRule)(lhs, rhs, options);
 }
 

--- a/test/demos.mjs
+++ b/test/demos.mjs
@@ -26,7 +26,7 @@ describe('Design-driving demos', function () {
                  typeAndNote.score(20)),
             rule(dom('title'),
                  typeAndNote.score(10).note(fnode => fnode.element.text)),
-            rule(type('titley').max(), out('bestTitle'))
+            rule(type('titley').max(), 'bestTitle')
         ]);
         const facts = rules.against(doc);
         const node = facts.get('bestTitle')[0];

--- a/test/lhs_tests.mjs
+++ b/test/lhs_tests.mjs
@@ -20,7 +20,7 @@ describe('LHS', function () {
         const rules = ruleset([
             rule(dom('p'), type('smoo').score(2)),
             rule(dom('div'), type('smoo').score(5)),
-            rule(type('smoo').max(), out('best'))
+            rule(type('smoo').max(), 'best')
         ]);
         const facts = rules.against(doc);
         const best = facts.get('best');
@@ -35,7 +35,7 @@ describe('LHS', function () {
         `);
         const rules = ruleset([
             rule(dom('div'), type('smoo')),
-            rule(type('smoo').bestCluster(), out('cluster'))
+            rule(type('smoo').bestCluster(), 'cluster')
         ]);
         const facts = rules.against(doc);
         assert.deepEqual(facts.get('cluster'), []);
@@ -45,7 +45,7 @@ describe('LHS', function () {
         const doc = staticDom('<p></p>');
         const rules = ruleset([
             rule(dom('p'), type('bar')),
-            rule(type('foo').type('bar'), out('best'))
+            rule(type('foo').type('bar'), 'best')
         ]);
         const facts = rules.against(doc);
         const best = facts.get('best');
@@ -57,7 +57,7 @@ describe('LHS', function () {
         const rules = ruleset([
             rule(dom('p'), type('bar')),
             rule(type('bar').when(fnode => fnode.element.id === 'fat'), type('when')),
-            rule(type('when'), out('best'))
+            rule(type('when'), 'best')
         ]);
         const facts = rules.against(doc);
         const best = facts.get('best');
@@ -69,7 +69,7 @@ describe('LHS', function () {
         const doc = staticDom('<p id="fat"></p><p id="bat"></p>');
         const rules = ruleset([
             rule(dom('p').when(fnode => fnode.element.id === 'bat'), type('when')),
-            rule(type('when'), out('best'))
+            rule(type('when'), 'best')
         ]);
         const facts = rules.against(doc);
         const best = facts.get('best');

--- a/test/ruleset_tests.mjs
+++ b/test/ruleset_tests.mjs
@@ -50,7 +50,7 @@ describe('Ruleset', function () {
             `);
             const rules = ruleset([
                 rule(dom('div'), type('paragraphish')),
-                rule(type('paragraphish'), out('p'))
+                rule(type('paragraphish'), 'p')
             ]);
             assert.equal(rules.against(doc).get('p').length, 1);
         });
@@ -225,7 +225,7 @@ describe('Ruleset', function () {
                 rule(dom('p'), type('b')),
                 rule(type('a'), props(fnode => ({type: 'c'})).typeIn('c')),
                 rule(type('b'), props(fnode => ({type: 'd'})).typeIn('d')),
-                rule(type('c'), out('c'))
+                rule(type('c'), 'c')
             ]);
             const facts = rules.against(doc);
             const p = facts.get('c')[0];
@@ -256,8 +256,8 @@ describe('Ruleset', function () {
         const rules = ruleset([
             rule(dom('a'), type('A')),
             rule(type('A'), type('B')),
-            rule(type('A'), out('ay')),
-            rule(type('B'), out('be'))
+            rule(type('A'), 'ay'),
+            rule(type('B'), 'be')
         ]);
         const ruleList = rules.rules();
         assert.equal(ruleList.length, 4);  // because deepEqual doesn't actually deep-compare Maps yet
@@ -273,7 +273,7 @@ describe('Ruleset', function () {
         const rules = ruleset([
             rule(dom('#root'), type('smoo').score(10)),
             rule(dom('#inner'), type('smoo').score(5)),
-            rule(type('smoo').max(), out('best'))
+            rule(type('smoo').max(), 'best')
         ]);
         const facts = rules.against(doc);
         const best = facts.get('best');

--- a/test/utils_tests.mjs
+++ b/test/utils_tests.mjs
@@ -46,7 +46,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {
@@ -66,7 +66,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {
@@ -86,7 +86,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {
@@ -107,7 +107,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {
@@ -127,7 +127,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {
@@ -146,7 +146,7 @@ describe('Utils', function () {
             const rules = ruleset([
                 rule(dom('img'), type('attr')),
                 rule(type('attr'), score(scoreFunc)),
-                rule(type('attr').max(), out('best'))
+                rule(type('attr').max(), 'best')
             ]);
 
             function scoreFunc(fnode) {


### PR DESCRIPTION
Addresses #51.

Allows users to omit the explicit call to `out()` when specifying their output rules. Users can now simply use the key string as the RHS of the rule. For example: `rule(type('titley').max(), out('title'))` can now be written as `rule(type('titley').max(), 'title')`.