### PR TITLE
Move resources with pick

### DIFF
--- a/cli/fathom_web/commands/extract.py
+++ b/cli/fathom_web/commands/extract.py
@@ -87,7 +87,7 @@ def extract_base64_data_from_html_page(file: pathlib.Path):
         html = fp.read()
 
     # Make the subresources directory
-    subresources_directory = file.parent / 'resources' / f'{file.stem}_resources'
+    subresources_directory = file.parent / 'resources' / f'{file.stem}'
     subresources_directory.mkdir(parents=True, exist_ok=True)
 
     offset = 0

--- a/cli/fathom_web/commands/pick.py
+++ b/cli/fathom_web/commands/pick.py
@@ -2,7 +2,7 @@ import pathlib
 from random import sample
 from shutil import move
 
-from click import argument, command, Path
+from click import argument, command, Path, UsageError
 
 
 @command()
@@ -23,14 +23,13 @@ def main(from_dir, to_dir, number):
     from_dir = pathlib.Path(from_dir)
     to_dir = pathlib.Path(to_dir)
 
-    files = [f for f in from_dir.glob('*.html')]
-    for file in sample(files, number):
-        # If the file has resources, we must move those as well
+    for file in sample(list(from_dir.glob('*.html')), number):
+        # If the file has resources, we must move those as well:
         if (from_dir / 'resources' / file.stem).exists():
             # Make sure we don't overwrite an existing resources directory
             if (to_dir / 'resources' / file.stem).exists():
-                raise RuntimeError(f'Tried to make directory {(to_dir / "resources" / file.stem).as_posix()}, but it'
-                                   f' already exists. To protect against unwanted data loss, please move or remove the'
-                                   f' existing directory.')
+                raise UsageError(f'Tried to make directory {(to_dir / "resources" / file.stem).as_posix()}, but it'
+                                 f' already exists. To protect against unwanted data loss, please move or remove the'
+                                 f' existing directory.')
             move(from_dir / 'resources' / file.stem, to_dir / 'resources' / file.stem)
         move(file.as_posix(), to_dir)

--- a/cli/fathom_web/commands/pick.py
+++ b/cli/fathom_web/commands/pick.py
@@ -12,7 +12,7 @@ from click import argument, command, Path
           type=Path(exists=True, file_okay=False, writable=True, dir_okay=True, allow_dash=True))
 @argument('number', type=int)
 def main(from_dir, to_dir, number):
-    """Move a given number of html files and any extracted resources from one directory to another.
+    """Move a given number of HTML files and any extracted resources from one directory to another.
 
     Ignore hidden files.
 

--- a/cli/fathom_web/test/test_pick.py
+++ b/cli/fathom_web/test/test_pick.py
@@ -15,28 +15,17 @@ def test_end_to_end(tmp_path):
     destination.mkdir()
 
     # Add files to the source directory
-    file_1 = source / '1.html'
-    file_1.write_text('I am file 1')
-    file_2 = source / '2.html'
-    file_2.write_text('I am file 2')
-    file_3 = source / '3.html'
-    file_3.write_text('I am file 3')
+    (source / '1.html').touch()
+    (source / '2.html').touch()
+    (source / '3.html').touch()
 
     # Add resource directories for files 1 and 2
-    resources = source / 'resources'
-    resources.mkdir()
-    file_1_resources = resources / '1'
-    file_1_resources.mkdir()
-    file_1_resource_1 = file_1_resources / '1.png'
-    file_1_resource_1.write_text('I am resource 1 for file 1')
-    file_1_resource_2 = file_1_resources / '2.css'
-    file_1_resource_2.write_text('I am resource 2 for file 1')
-    file_2_resources = resources / '2'
-    file_2_resources.mkdir()
-    file_2_resource_1 = file_2_resources / '1.png'
-    file_2_resource_1.write_text('I am resource 1 for file 2')
-    file_2_resource_2 = file_2_resources / '2.css'
-    file_2_resource_2.write_text('I am resource 2 for file 2')
+    (source / 'resources' / '1').mkdir(parents=True)
+    (source / 'resources' / '1' / '1.png').touch()
+    (source / 'resources' / '1' / '2.css').touch()
+    (source / 'resources' / '2').mkdir(parents=True)
+    (source / 'resources' / '2' / '1.png').touch()
+    (source / 'resources' / '2' / '2.css').touch()
 
     # Run fathom-pick to move 2 files from source to destination
     runner = CliRunner()
@@ -75,31 +64,24 @@ def test_resource_directory_path_collision(tmp_path):
     destination.mkdir()
 
     # Add the file to the source directory
-    file_1 = source / '1.html'
-    file_1.write_text('I am file 1')
+    (source / '1.html').touch()
 
     # Add the resource directory for our file
-    resources = source / 'resources'
-    resources.mkdir()
-    file_1_resources = resources / '1'
-    file_1_resources.mkdir()
-    file_1_resource_1 = file_1_resources / '1.png'
-    file_1_resource_1.write_text('I am resource 1 for file 1')
-    file_1_resource_2 = file_1_resources / '2.css'
-    file_1_resource_2.write_text('I am resource 2 for file 1')
+    (source / 'resources' / '1').mkdir(parents=True)
+    (source / 'resources' / '1' / '1.png').touch()
+    (source / 'resources' / '1' / '2.css').touch()
 
     # Add a resource directory for the same file in the destination directory
-    conflicting_resources = destination / 'resources' / '1'
-    conflicting_resources.mkdir(parents=True)
+    (destination / 'resources' / '1').mkdir(parents=True)
 
     # Run fathom-pick to move the only file from source to destination
     runner = CliRunner()
     # Arguments to invoke() must be passed as strings (this isn't documented!!!)
     result = runner.invoke(pick_main, [source.as_posix(), destination.as_posix(), '1'])
 
-    # Assert the program exited with an error and the exception message is about creating a directory
-    assert result.exit_code == 1
-    assert str(result.exc_info[1]).startswith('Tried to make directory')
+    # Assert the program exited with a UsageError and our error message is in the program output
+    assert result.exit_code == 2
+    assert 'Error: Tried to make directory' in result.output
 
     # Check that our files haven't moved
     files_in_source = list(source.glob('*.html'))
@@ -108,3 +90,4 @@ def test_resource_directory_path_collision(tmp_path):
     assert (source / 'resources' / '1' / '2.css').exists()
     files_in_destination = list(destination.glob('*.html'))
     assert len(files_in_destination) == 0
+    assert (destination / 'resources' / '1').exists()

--- a/cli/fathom_web/test/test_pick.py
+++ b/cli/fathom_web/test/test_pick.py
@@ -1,0 +1,63 @@
+from click.testing import CliRunner
+
+from ..commands.pick import main as pick_main
+
+
+def test_end_to_end(tmp_path):
+    """
+    Given a directory of three files, use ``fathom-pick`` to move two files, and
+    check that the files and their potential resources directories have moved.
+    """
+    # Make temporary source and destination directories
+    source = tmp_path / 'source'
+    source.mkdir()
+    destination = tmp_path / 'destination'
+    destination.mkdir()
+
+    # Add files to the source directory
+    file_1 = source / '1.html'
+    file_1.write_text('I am file 1')
+    file_2 = source / '2.html'
+    file_2.write_text('I am file 2')
+    file_3 = source / '3.html'
+    file_3.write_text('I am file 3')
+
+    # Add resource directories for files 1 and 2
+    resources = source / 'resources'
+    resources.mkdir()
+    file_1_resources = resources / '1'
+    file_1_resources.mkdir()
+    file_1_resource_1 = file_1_resources / '1.png'
+    file_1_resource_1.write_text('I am resource 1 for file 1')
+    file_1_resource_2 = file_1_resources / '2.css'
+    file_1_resource_2.write_text('I am resource 2 for file 1')
+    file_2_resources = resources / '2'
+    file_2_resources.mkdir()
+    file_2_resource_1 = file_2_resources / '1.png'
+    file_2_resource_1.write_text('I am resource 1 for file 2')
+    file_2_resource_2 = file_2_resources / '2.css'
+    file_2_resource_2.write_text('I am resource 2 for file 2')
+
+    # Run fathom-pick to move 2 files from source to destination
+    runner = CliRunner()
+    # Arguments to invoke() must be passed as strings (this isn't documented!!!)
+    result = runner.invoke(pick_main, [source.as_posix(), destination.as_posix(), '2'])
+    assert result.exit_code == 0
+
+    # Check the correct number of files have moved
+    files_in_source = list(source.glob('*.html'))
+    assert len(files_in_source) == 1
+    files_in_destination = list(destination.glob('*.html'))
+    assert len(files_in_destination) == 2
+
+    # Check any resource directories have moved
+    if (destination / '1.html').exists():
+        assert (destination / 'resources' / '1' / '1.png').exists()
+        assert (destination / 'resources' / '1' / '2.css').exists()
+    if (destination / '2.html').exists():
+        assert (destination / 'resources' / '2' / '1.png').exists()
+        assert (destination / 'resources' / '2' / '2.css').exists()
+
+    # Make sure we didn't lose any files
+    files_in_directories = {file.name for file in files_in_source} | {file.name for file in files_in_destination}
+    assert {'1.html', '2.html', '3.html'} == files_in_directories


### PR DESCRIPTION
Addresses #125 

This PR changes `fathom-pick` such that it specifically moves HTML files and any extracted resources. Now that samples will almost certainly have an associated directory of extracted resources, we need to move those resources along with the HTML files when dividing samples into training/validation/test so the references to the resources in the HTML still work.