### PR TITLE
Fix #138: Add fathom-label CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 !/test/browser/*
 /cli/build
 /cli/dist
+**/__pycache__
+/cli/*.egg-info

--- a/cli/fathom_web/commands/label.py
+++ b/cli/fathom_web/commands/label.py
@@ -1,0 +1,87 @@
+from html.parser import HTMLParser
+import pathlib
+import re
+import shutil
+
+from click import argument, command, option, Path, STRING
+
+
+@command()
+@option('--preserve-originals/--no-preserve-originals',
+        default=True,
+        help='Save original HTML files in a newly created `originals`'
+             ' directory in IN_DIRECTORY (default: True)')
+@argument('in_directory', type=Path(exists=True, file_okay=False))
+@argument('in_type', type=STRING)
+def main(in_directory, in_type, preserve_originals):
+    """
+    Add the ``data-fathom`` attribute with a value of IN_TYPE to the
+    opening tag of any ``<html>`` elements in the HTML pages in
+    IN_DIRECTORY. This tool is used to label an entire webpage (e.g.
+    IN_TYPE could be "article" for article webpages).
+    """
+    if preserve_originals:
+        originals_dir = pathlib.Path(in_directory) / 'originals'
+        try:
+            originals_dir.mkdir(parents=True)
+        except FileExistsError:
+            raise RuntimeError(f'Tried to make directory {originals_dir.as_posix()}, but it already exists. To protect'
+                               f' against unwanted data loss, please move or remove the existing directory.')
+    else:
+        originals_dir = None
+
+    for file in pathlib.Path(in_directory).iterdir():
+        if file == originals_dir:
+            continue
+        if file.is_dir():
+            print(f'Skipping directory {file.name}/')
+            continue
+        if file.suffix != '.html':
+            print(f'Skipping {file.name}; not an HTML file')
+            continue
+
+        with file.open(encoding='utf-8') as fp:
+            html = fp.read()
+
+        new_html = label_html_tags_in_html_string(html, in_type)
+
+        if preserve_originals:
+            shutil.move(file, originals_dir / file.name)
+
+        with file.open('w', encoding='utf-8') as fp:
+            fp.write(new_html)
+
+
+class HTMLParserSubclass(HTMLParser):
+    def __init__(self, in_type, **kwargs):
+        self.in_type = in_type
+        self.html_tags_list = []
+        super().__init__(**kwargs)
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'html':
+            original_html_tag = self.get_starttag_text()
+            new_html_substring = f'html data-fathom="{self.in_type}"'
+            new_html_tag = original_html_tag.replace('html', new_html_substring, 1)
+            self.html_tags_list.append(tuple([original_html_tag, new_html_tag]));
+
+
+def label_html_tags_in_html_string(html: str, in_type: str) -> str:
+    """
+    Finds all opening ``html`` tags in the HTML string and adds a
+    ``' data-fathom="${in_type}"'`` substring to each one.
+
+    We do this by building a new HTML string with the inserted substring(s).
+
+    The ``html`` tags are found using the HTMLParser class in Python's
+    built-in html.parser library.
+    """
+    parser = HTMLParserSubclass(in_type)
+    parser.feed(html);
+
+    new_html = html
+
+    for (original_html_tag, new_html_tag) in parser.html_tags_list:
+        new_html = new_html.replace(original_html_tag, new_html_tag, 1);
+
+    return new_html

--- a/cli/fathom_web/test/test_label.py
+++ b/cli/fathom_web/test/test_label.py
@@ -1,0 +1,67 @@
+from ..commands.label import label_html_tags_in_html_string
+
+
+IN_TYPE = 'test'
+
+
+def test_opening_html_tag_has_no_attributes():
+    """Some HTML tags may not have any attributes"""
+    input_string = '<html>'
+    expected_string = f'<html data-fathom="{IN_TYPE}">'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_opening_html_tag_has_attributes():
+    """Most HTML tags have at least one attribute"""
+    input_string = '<html lang="en-us">'
+    expected_string = f'<html data-fathom="{IN_TYPE}" lang="en-us">'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_html_string_has_multiple_opening_html_tags():
+    """Some HTML tags may have multiple HTML tags"""
+    input_string = '<html><div></div><html>'
+    expected_string = f'<html data-fathom="{IN_TYPE}"><div></div><html data-fathom="{IN_TYPE}">'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_html_string_has_right_angle_bracket_as_attribute_value():
+    """Some HTML tags may contain a right angle bracket in an unexpected location."""
+    input_string = '<html data-bracket=">" class="foo">'
+    expected_string = f'<html data-fathom="{IN_TYPE}" data-bracket=">" class="foo">'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_html_string_is_multiline():
+    """Some HTML tags may span multiple lines"""
+    input_string ='<html\n' + \
+                'class="foo"\n' + \
+                'id="bar"\n' + \
+                '>'
+    expected_string = f'<html data-fathom="{IN_TYPE}"\n' + \
+                'class="foo"\n' + \
+                'id="bar"\n' + \
+                '>'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_html_string_has_extra_spaces():
+    """
+    Some HTML tags may have extra spaces inside the HTML tag. Note that having a space
+    between the '<' and the tag name (e.g. 'html') is not valid HTML.
+    """
+    input_string ='<html   >'
+    expected_string = f'<html data-fathom="{IN_TYPE}"   >'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string
+
+
+def test_html_string_has_comments():
+    """
+    Some HTML tags may have HTML comments throughout. Note that comments cannot
+    occur within a tag.
+    """
+    input_string = '<!-- this is a comment --><html lang="en">\n' + \
+    '<!-- this is another comment --></html><!-- this is yet another comment -->'
+    expected_string = f'<!-- this is a comment --><html data-fathom="{IN_TYPE}" lang="en">\n' + \
+    '<!-- this is another comment --></html><!-- this is yet another comment -->'
+    assert label_html_tags_in_html_string(input_string, IN_TYPE) == expected_string

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -15,10 +15,10 @@ setup(
     install_requires=['click>=7.0,<8.0', 'tensorboardX>=1.6,<2.0', 'torch>=1.0,<2.0'],
     entry_points={'console_scripts': [
         'fathom-extract = fathom_web.commands.extract:main',
+        'fathom-label = fathom_web.commands.label:main',
         'fathom-list = fathom_web.commands.list:main',
         'fathom-pick = fathom_web.commands.pick:main',
         'fathom-serve = fathom_web.commands.serve:main',
-        'fathom-label = fathom_web.commands.label:main',
         'fathom-test = fathom_web.commands.test:main',
         'fathom-train = fathom_web.commands.train:main',
         'fathom-unzip = fathom_web.commands.unzip:main',

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -18,6 +18,7 @@ setup(
         'fathom-list = fathom_web.commands.list:main',
         'fathom-pick = fathom_web.commands.pick:main',
         'fathom-serve = fathom_web.commands.serve:main',
+        'fathom-label = fathom_web.commands.label:main',
         'fathom-test = fathom_web.commands.test:main',
         'fathom-train = fathom_web.commands.train:main',
         'fathom-unzip = fathom_web.commands.unzip:main',


### PR DESCRIPTION
* This is largely based off of the 'fathom-extract' CLI.
* This tool handles documents with multiple 'html' elements by capturing each original opening html tag and each modified opening html tag in a list of tuples and iterating through each tuple to 'string.replace' to update the HTML document.
* I originally had a test that asserted that '< html >' became '< html data-fathom="test" >', but I discovered that this isn't valid HTML per the [specification](https://www.w3.org/TR/html53/syntax.html#start-tags)
* Similarly, there is no test for comments inside an 'html' tag, because that is also invalid HTML.

Open question: Is `fathom-label` descriptive enough? This tool only labels an entire page, so perhaps we can be more specific. Suggestions welcome!