### PR TITLE
Updates decode to work on unpadded base64 strings

### DIFF
--- a/cli/fathom_web/commands/extract.py
+++ b/cli/fathom_web/commands/extract.py
@@ -163,10 +163,20 @@ def generate_filename(mime_type: str, filename: str) -> str:
 
 def decode(base64_string: str) -> bytes:
     """
-    Decodes the base64 string into bytes. If as string has any additional
-    encoding (ex. percent encoding of the padding characters), decode that
-    first.
+    Decodes the base64 string into bytes.
+
+    If as string has any additional encoding (ex. percent encoding of the
+    padding characters), decode that first.
+
+    We also check if the string is padded to a number of characters that is a
+    multiple of four, which is what base64.b64decode() requires.
     """
+    # Percent encoding
     if '%' in base64_string:
         base64_string = unquote(base64_string)
+    # Padding check
+    string_mod_4 = len(base64_string) % 4
+    if string_mod_4 != 0:
+        base64_string += "=" * (4 - string_mod_4)
+
     return base64.b64decode(base64_string)

--- a/cli/fathom_web/commands/extract.py
+++ b/cli/fathom_web/commands/extract.py
@@ -177,6 +177,6 @@ def decode(base64_string: str) -> bytes:
     # Padding check
     string_mod_4 = len(base64_string) % 4
     if string_mod_4 != 0:
-        base64_string += "=" * (4 - string_mod_4)
+        base64_string += '=' * (4 - string_mod_4)
 
     return base64.b64decode(base64_string)

--- a/cli/fathom_web/test/test_extract.py
+++ b/cli/fathom_web/test/test_extract.py
@@ -61,3 +61,15 @@ def test_string_with_percent_encoded_equals_signs_is_decoded():
     """
     base64_string = 'R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D'
     decode(base64_string)
+
+
+def test_unpadded_string_is_decoded():
+    """Some base64 strings do not have padding characters. Python's
+    base64.b64decode() expects the string to be padded to a number of
+    characters that is a multiple of four.
+
+    At the moment, we will trust the decoding is correct, we just want
+    to make sure no errors are raised.
+    """
+    base64_string = 'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs'
+    decode(base64_string)


### PR DESCRIPTION
I encountered frozen pages with unpadded base64 strings. Python's `base64.b64decode()` method requires padded strings, so this PR pads strings that are unpadded.

@biancadanforth: You may need this for your samples.