### PR TITLE
Make `fathom list` a specialized tool for FathomFox

### DIFF
--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -41,7 +41,6 @@ def main(in_directory, base_dir, recursive, out_file):
         if out_file is not None:
             filenames_to_save.append(relative_path.as_posix() + '\n')
 
-
     if out_file is not None:
         if there_were_no_files:
             print(f'No .html files found in {in_directory}. Did not create {out_file}.')

--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -32,12 +32,18 @@ def main(in_directory, base_dir, recursive, out_file):
     if out_file is not None:
         filenames_to_save = []
 
+    there_were_no_files = True
     for file in path_iterator:
+        there_were_no_files = False
         relative_path = file.relative_to(base_dir)
         print(relative_path)
 
         if out_file is not None:
             filenames_to_save.append(relative_path.as_posix() + '\n')
 
+
     if out_file is not None:
-        out_file.writelines(filenames_to_save)
+        if there_were_no_files:
+            print(f'No .html files found in {in_directory}. Did not create {out_file}.')
+        else:
+            out_file.writelines(filenames_to_save)

--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -4,30 +4,40 @@ from click import argument, command, File, option, Path
 
 
 @command()
+@argument('in_directory', type=Path(exists=True, file_okay=False))
+@option('--base-dir', '-b', type=Path(exists=True, file_okay=False),
+        help='The directory to create relative paths from.')
+@option('--recursive', '-r', default=False, is_flag=True,
+        help='Recursively list files from the IN_DIRECTORY and all subdirectories.')
 @option('--out-file', '-o', type=File(mode='w'), default=None,
         help='A file for saving the printed filenames for easy future reference.')
-@argument('in_directory', type=Path(exists=True, file_okay=False))
-def main(in_directory, out_file):
+def main(in_directory, base_dir, recursive, out_file):
     """
-    Lists filenames in a IN_DIRECTORY, one filename per line. Optionally saves output to OUT_FILE.
-
-    Ignores hidden files.
+    Lists relative paths of HTML files in a IN_DIRECTORY relative to BASE_DIR, one filename per line.
+    If BASE_DIR is not specified, paths are relative to IN_DIRECTORY. Optionally saves output to OUT_FILE.
+    Optionally performs the listing recursively.
 
     This is useful for vectorizing samples using FathomFox. FathomFox expects input filenames copied into a text box
-    with one filename per line.
+    with one filename per line and relative to some path you are serving files from using fathom-serve.
     """
+    if base_dir is None:
+        base_dir = in_directory
+    base_dir = pathlib.Path(base_dir)
+
+    if recursive:
+        path_iterator = pathlib.Path(in_directory).rglob('*.html')
+    else:
+        path_iterator = pathlib.Path(in_directory).glob('*.html')
+
     if out_file is not None:
         filenames_to_save = []
 
-    for file in pathlib.Path(in_directory).iterdir():
-        # Ignore hidden files
-        if file.name.startswith('.'):
-            continue
-
-        print(file.name)
+    for file in path_iterator:
+        relative_path = file.relative_to(base_dir)
+        print(relative_path)
 
         if out_file is not None:
-            filenames_to_save.append(file.name + '\n')
+            filenames_to_save.append(relative_path.as_posix() + '\n')
 
     if out_file is not None:
         out_file.writelines(filenames_to_save)

--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -43,6 +43,6 @@ def main(in_directory, base_dir, recursive, out_file):
 
     if out_file is not None:
         if there_were_no_files:
-            print(f'No .html files found in {in_directory}. Did not create {out_file}.')
+            print(f'No .html files found in {in_directory}. Did not create {out_file.name}.')
         else:
             out_file.writelines(filenames_to_save)

--- a/cli/fathom_web/test/test_list.py
+++ b/cli/fathom_web/test/test_list.py
@@ -79,7 +79,7 @@ def test_no_files_to_list(tmp_path):
     )
     assert result.exit_code == 0
 
-    expected_file_contents = ""
+    expected_file_contents = ''
     actual_file_contents = out_file.read_text()
     assert expected_file_contents == actual_file_contents
 
@@ -140,7 +140,7 @@ def test_without_recursive(tmp_path):
     )
     assert result.exit_code == 0
 
-    expected_file_contents = ""
+    expected_file_contents = ''
     actual_file_contents = out_file.read_text()
     assert expected_file_contents == actual_file_contents
 

--- a/cli/fathom_web/test/test_list.py
+++ b/cli/fathom_web/test/test_list.py
@@ -20,20 +20,22 @@ def test_end_to_end(tmp_path):
         list_main,
         [
             in_directory.as_posix(),
-            f'-b{base_dir.as_posix()}',
+            '-b',
+            f'{base_dir.as_posix()}',
             '-r',
-            f'-o{out_file.as_posix()}',
+            '-o',
+            f'{out_file.as_posix()}',
         ],
     )
     assert result.exit_code == 0
 
-    expected_file_contents = [
+    expected_file_contents = {
         a1.relative_to(base_dir).as_posix(),
         a2.relative_to(base_dir).as_posix(),
         b1.relative_to(base_dir).as_posix(),
         b2.relative_to(base_dir).as_posix(),
-    ]
-    actual_file_contents = out_file.read_text().splitlines()
+    }
+    actual_file_contents = set(out_file.read_text().splitlines())
     assert expected_file_contents == actual_file_contents
 
 
@@ -74,14 +76,13 @@ def test_no_files_to_list(tmp_path):
         list_main,
         [
             in_directory.as_posix(),
-            f'-o{out_file.as_posix()}',
+            '-o',
+            f'{out_file.as_posix()}',
         ],
     )
     assert result.exit_code == 0
 
-    expected_file_contents = ''
-    actual_file_contents = out_file.read_text()
-    assert expected_file_contents == actual_file_contents
+    assert 'No .html files found' in result.output
 
 
 def test_without_base_dir(tmp_path):
@@ -102,18 +103,19 @@ def test_without_base_dir(tmp_path):
         [
             in_directory.as_posix(),
             '-r',
-            f'-o{out_file.as_posix()}',
+            '-o',
+            f'{out_file.as_posix()}',
         ],
     )
     assert result.exit_code == 0
 
-    expected_file_contents = [
+    expected_file_contents = {
         a1.relative_to(in_directory).as_posix(),
         a2.relative_to(in_directory).as_posix(),
         b1.relative_to(in_directory).as_posix(),
         b2.relative_to(in_directory).as_posix(),
-    ]
-    actual_file_contents = out_file.read_text().splitlines()
+    }
+    actual_file_contents = set(out_file.read_text().splitlines())
     assert expected_file_contents == actual_file_contents
 
 
@@ -134,15 +136,15 @@ def test_without_recursive(tmp_path):
         list_main,
         [
             in_directory.as_posix(),
-            f'-b{base_dir.as_posix()}',
-            f'-o{out_file.as_posix()}',
+            '-b',
+            f'{base_dir.as_posix()}',
+            '-o',
+            f'{out_file.as_posix()}',
         ],
     )
     assert result.exit_code == 0
 
-    expected_file_contents = ''
-    actual_file_contents = out_file.read_text()
-    assert expected_file_contents == actual_file_contents
+    assert 'No .html files found' in result.output
 
 
 def test_in_directory_does_not_exist():
@@ -168,7 +170,8 @@ def test_base_dir_does_not_exist(tmp_path):
         list_main,
         [
             in_directory.as_posix(),
-            '-bfake_base_dir',
+            '-b',
+            'fake_base_dir',
         ],
     )
     # Assert the program exited with an error message about base_dir not existing

--- a/cli/fathom_web/test/test_list.py
+++ b/cli/fathom_web/test/test_list.py
@@ -1,0 +1,176 @@
+from click.testing import CliRunner
+
+from ..commands.list import main as list_main
+
+
+def test_end_to_end(tmp_path):
+    """Test expected outcome when using all of the optional parameters"""
+    # Make temporary in_directory and base_dir directories
+    base_dir, in_directory = make_directories(tmp_path)
+
+    # Make HTML files in in_directory in two separate subdirectories
+    # so we can exercise the recursive option.
+    a1, a2, b1, b2 = make_html_files(in_directory)
+
+    # Make the out_file we will save the output to
+    out_file = (base_dir / 'out_file.txt')
+
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            in_directory.as_posix(),
+            f'-b{base_dir.as_posix()}',
+            '-r',
+            f'-o{out_file.as_posix()}',
+        ],
+    )
+    assert result.exit_code == 0
+
+    expected_file_contents = [
+        a1.relative_to(base_dir).as_posix(),
+        a2.relative_to(base_dir).as_posix(),
+        b1.relative_to(base_dir).as_posix(),
+        b2.relative_to(base_dir).as_posix(),
+    ]
+    actual_file_contents = out_file.read_text().splitlines()
+    assert expected_file_contents == actual_file_contents
+
+
+def make_directories(tmp_path):
+    """Makes the directories used as base_dir and in_directory in our fathom-list calls"""
+    base_dir = tmp_path / 'base_dir'
+    base_dir.mkdir()
+    in_directory = base_dir / 'in_directory'
+    in_directory.mkdir()
+    return base_dir, in_directory
+
+
+def make_html_files(in_directory):
+    """Makes four HTML files in a common directory structure for using in our fathom-list calls"""
+    (in_directory / 'source_a').mkdir()
+    a1 = (in_directory / 'source_a' / '1.html')
+    a1.touch()
+    a2 = (in_directory / 'source_a' / '2.html')
+    a2.touch()
+    (in_directory / 'source_b').mkdir()
+    b1 = (in_directory / 'source_b' / '1.html')
+    b1.touch()
+    b2 = (in_directory / 'source_b' / '2.html')
+    b2.touch()
+    return a1, a2, b1, b2
+
+
+def test_no_files_to_list(tmp_path):
+    """Test an empty in_directory using all of the optional parameters"""
+    # Make temporary in_directory and base_dir directories
+    base_dir, in_directory = make_directories(tmp_path)
+
+    # Make the out_file we will save the output to
+    out_file = (in_directory / 'out_file.txt')
+
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            in_directory.as_posix(),
+            f'-o{out_file.as_posix()}',
+        ],
+    )
+    assert result.exit_code == 0
+
+    expected_file_contents = ""
+    actual_file_contents = out_file.read_text()
+    assert expected_file_contents == actual_file_contents
+
+
+def test_without_base_dir(tmp_path):
+    """Test omission of base-dir parameter"""
+    # Make temporary in_directory and base_dir directories
+    base_dir, in_directory = make_directories(tmp_path)
+
+    # Make HTML files in in_directory in two separate subdirectories
+    # so we can exercise the recursive option.
+    a1, a2, b1, b2 = make_html_files(in_directory)
+
+    # Make the out_file we will save the output to
+    out_file = (base_dir / 'out_file.txt')
+
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            in_directory.as_posix(),
+            '-r',
+            f'-o{out_file.as_posix()}',
+        ],
+    )
+    assert result.exit_code == 0
+
+    expected_file_contents = [
+        a1.relative_to(in_directory).as_posix(),
+        a2.relative_to(in_directory).as_posix(),
+        b1.relative_to(in_directory).as_posix(),
+        b2.relative_to(in_directory).as_posix(),
+    ]
+    actual_file_contents = out_file.read_text().splitlines()
+    assert expected_file_contents == actual_file_contents
+
+
+def test_without_recursive(tmp_path):
+    """Test omission of recursive parameter results in an empty output file"""
+    base_dir, in_directory = make_directories(tmp_path)
+
+    # Make HTML files in in_directory in two separate subdirectories.
+    # We will see that fathom-list should not find these files since
+    # the recursive option is not used.
+    make_html_files(in_directory)
+
+    # Make the out_file we will save the output to
+    out_file = (base_dir / 'out_file.txt')
+
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            in_directory.as_posix(),
+            f'-b{base_dir.as_posix()}',
+            f'-o{out_file.as_posix()}',
+        ],
+    )
+    assert result.exit_code == 0
+
+    expected_file_contents = ""
+    actual_file_contents = out_file.read_text()
+    assert expected_file_contents == actual_file_contents
+
+
+def test_in_directory_does_not_exist():
+    """Test giving an invalid path for in_directory causes an error"""
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            'fake_in_dir',
+        ],
+    )
+    # Assert the program exited with an error message about in directory not existing
+    assert result.exit_code == 2
+    assert '"fake_in_dir" does not exist.' in result.output
+
+
+def test_base_dir_does_not_exist(tmp_path):
+    """Test giving an invalid path for base-dir causes an error"""
+    _, in_directory = make_directories(tmp_path)
+
+    # Run fathom-list
+    result = CliRunner().invoke(
+        list_main,
+        [
+            in_directory.as_posix(),
+            '-bfake_base_dir',
+        ],
+    )
+    # Assert the program exited with an error message about base_dir not existing
+    assert result.exit_code == 2
+    assert '"fake_base_dir" does not exist.' in result.output


### PR DESCRIPTION
This PR makes `fathom-list` a specialized tool for FathomFox. I have found that I have needed to do a significant amount of work to create the filename lists I needed for vectorization, so I'm proposing `fathom-list` do all this work for us.

It is likely that training samples are not all in the same directory. You may the following directory structure (which is what we're currently recommending):
```
samples/
|-  training/
|    |-  source_a/
|    |    |-  positive/
|    |    |    |-  [lots of html files]
|    |    |-  negative/
|    |    |    |-  [lots of html files]
|    |-  source_b/
|    |    |-  positive/
|    |    |    |-  [lots of html files]
|    |    |-  negative/
|    |    |    |-  [lots of html files]
```
In this case, using `fathom-list` is not convenient for getting your sample filenames since the FathomFox wants paths relative to some base directory. In the past, I've served `samples/` as my base directory using `fathom-serve` so don't have to change it when switching between training and validation sets. Since I'm serving `samples/` my filenames need to be paths relative to `samples/`. To get this list I do the following:

1. Use `fathom-list` to list the files in one of the directories containing HTML files and save it to a file
2. Remove the `resources/` line from the file created in 1 since `fathom-list` lists all files.
3. Use `fathom-list` to list the files in each of the other directories and manually paste the filenames into the file I created in 1.
4. Prepend each filename with the path relative to `samples/`. I at least use a vim macro to do this part, though the macro has to change for each directory.

This proposed new `fathom-list` does this for you automatically. You can specify the base directory to make all the outputted paths relative to. You can also do the listing recursively. Now to generate the filenames for my training set, I run the following from my `samples/` directory:
```
fathom-list training -b . -r -o training.txt
```
This lists paths relative to `samples/` for all the HTML files in `training/`, recursively, and saves them to the file `training.txt`.