### PR TITLE
Adds confidence intervals for false positives and false negatives

### DIFF
--- a/cli/fathom_web/accuracy.py
+++ b/cli/fathom_web/accuracy.py
@@ -143,9 +143,14 @@ def accuracy_per_page(model, pages):
     return (successes / len(pages)), '\n'.join(report_lines)
 
 
-def pretty_accuracy(description, accuracy, number_of_samples, false_positive=None, false_negative=None):
+def pretty_accuracy(description, accuracy, number_of_samples, false_positive=None, false_negative=None, number_of_positives=None):
     ci_low, ci_high = confidence_interval(accuracy, number_of_samples)
-    falses = '' if false_positive is None else '  FP: {false_positive:.3f}  FN: {false_negative:.3f}'.format(false_positive=false_positive, false_negative=false_negative)
+    if false_positive is not None:
+        fp_ci_low, fp_ci_high = confidence_interval(false_positive, number_of_positives)
+        fn_ci_low, fn_ci_high = confidence_interval(false_negative, number_of_samples - number_of_positives)
+        falses = '  FP: {false_positive:.3f}    95% CI: ({fp_ci_low:.5f}, {fp_ci_high:.5f})  FN: {false_negative:.3f}    95% CI: ({fn_ci_low:.5f}, {fn_ci_high:.5f})'.format(false_positive=false_positive, fp_ci_low=fp_ci_low, fp_ci_high=fp_ci_high, false_negative=false_negative, fn_ci_low=fn_ci_low, fn_ci_high=fn_ci_high)
+    else:
+        falses = ''
     return '{description} {accuracy:.5f}    95% CI: ({ci_low:.5f}, {ci_high:.5f}){falses}'.format(description=description, accuracy=accuracy, ci_low=ci_low, ci_high=ci_high, falses=falses)
 
 

--- a/cli/fathom_web/commands/train.py
+++ b/cli/fathom_web/commands/train.py
@@ -118,17 +118,17 @@ def main(training_file, validation_file, stop_early, learning_rate, iterations, 
     x, y, num_yes = tensors_from(training_data['pages'], shuffle=True)
     if validation_file:
         validation_data = load(validation_file)
-        validation_ins, validation_outs, _ = tensors_from(validation_data['pages'])
+        validation_ins, validation_outs, validation_yes = tensors_from(validation_data['pages'])
         validation_arg = validation_ins, validation_outs
     else:
         validation_arg = None
     model = learn(learning_rate, iterations, x, y, validation=validation_arg, stop_early=stop_early, run_comment=full_comment)
     print(pretty_coeffs(model, training_data['header']['featureNames']))
     accuracy, false_positive, false_negative = accuracy_per_tag(y, model(x))
-    print(pretty_accuracy(('  ' if validation_file else '') + 'Training accuracy per tag: ', accuracy, len(x), false_positive, false_negative))
+    print(pretty_accuracy(('  ' if validation_file else '') + 'Training accuracy per tag: ', accuracy, len(x), false_positive, false_negative, num_yes))
     if validation_file:
         accuracy, false_positive, false_negative = accuracy_per_tag(validation_outs, model(validation_ins))
-        print(pretty_accuracy('Validation accuracy per tag: ', accuracy, len(validation_ins), false_positive, false_negative))
+        print(pretty_accuracy('Validation accuracy per tag: ', accuracy, len(validation_ins), false_positive, false_negative, validation_yes))
     accuracy, training_report = accuracy_per_page(model, training_data['pages'])
     print(pretty_accuracy(('  ' if validation_file else '') + 'Training accuracy per page:', accuracy, len(training_data['pages'])))
     if validation_file:


### PR DESCRIPTION
As the title suggests, this PR adds 95% confidence intervals to the output of the false positive and false negative metrics computed by fathom-train.