### PR TITLE
Make `fathom-serve` multithreaded.

### DIFF
--- a/cli/fathom_web/commands/serve.py
+++ b/cli/fathom_web/commands/serve.py
@@ -1,4 +1,4 @@
-import contextlib
+from contextlib import contextmanager
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import os
 
@@ -24,7 +24,7 @@ def main(directory, port):
         server.serve_forever()
 
 
-@contextlib.contextmanager
+@contextmanager
 def cd(path):
     previous_directory = os.getcwd()
     os.chdir(path)

--- a/cli/fathom_web/commands/serve.py
+++ b/cli/fathom_web/commands/serve.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import os
+from socketserver import ThreadingMixIn
 
 from click import command, option, Path
 
@@ -18,7 +19,7 @@ def main(directory, port):
     in the vectorizer page, an address to an HTTP server that is serving your samples.
     """
     with cd(directory):
-        server = HTTPServer(('localhost', port), SimpleHTTPRequestHandler)
+        server = ThreadingHTTPServer(('localhost', port), SimpleHTTPRequestHandler)
         print(f'Serving {directory} over http://localhost:{port}.')
         print('Press Ctrl+C to stop.')
         server.serve_forever()
@@ -32,3 +33,7 @@ def cd(path):
         yield
     finally:
         os.chdir(previous_directory)
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    pass

--- a/cli/fathom_web/commands/serve.py
+++ b/cli/fathom_web/commands/serve.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 import os
-from socketserver import ThreadingMixIn
 
 from click import command, option, Path
 
@@ -33,7 +32,3 @@ def cd(path):
         yield
     finally:
         os.chdir(previous_directory)
-
-
-class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
-    pass


### PR DESCRIPTION
Fix timeouts when vectorizing: https://github.com/mozilla/fathom-fox/issues/67.

For whatever reason, fathom-serve spits out errors like this while serving rapid-fire vectorization requests:
```
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/server.py", line 414, in handle_one_request
    method()
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/server.py", line 653, in do_GET
    self.copyfile(f, self.wfile)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/server.py", line 844, in copyfile
    shutil.copyfileobj(source, outputfile)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/shutil.py", line 82, in copyfileobj
    fdst.write(buf)
  File "/usr/local/Cellar/python/3.7.5/Frameworks/Python.framework/Versions/3.7/lib/python3.7/socketserver.py", line 799, in write
    self._sock.sendall(b)
BrokenPipeError: [Errno 32] Broken pipe
```

Maybe Firefox is hanging up prematurely or something. I don't know. But what appears to happen as a result is that a zillion other requests from the browser queue up behind the broken-pipe ones (which take awhile to time out) and thus end up timing out themselves. Moving to a multithreaded server at least lets each timeout happen in a dedicated thread so they don't bother other requests. On my 2017 MBP, Activity Monitor reports that fathom-serve usually has 1 thread going but perhaps 40% of the time has 2, 3, or rarely up to 5 concurrent threads. Thus, I'm not worried about this turning into a thread bomb.