### PR TITLE
fathom-histogram

### DIFF
--- a/cli/fathom_web/commands/histogram.py
+++ b/cli/fathom_web/commands/histogram.py
@@ -1,0 +1,24 @@
+from json import load
+
+from click import argument, command, File, option, progressbar
+from plotly.express import histogram
+from plotly.subplots import make_subplots
+
+from ..utils import classifier, tensor, tensors_from
+
+
+@command()
+@argument('vector_file', type=File('r'))
+@argument('feature', type=str)
+def main(vector_file, feature):
+    """Print a histogram of the given feature."""
+    data = load(vector_file)
+    x, y, num_yes = tensors_from(data['pages'])
+
+    feature_index = data['header']['featureNames'].index(feature)
+    feature_values = []
+    for page in data['pages']:
+        for node in page['nodes']:
+            feature_values.append(node['features'][feature_index])
+
+    histogram({feature: feature_values}, x=feature, nbins=40).show()

--- a/cli/fathom_web/commands/histogram.py
+++ b/cli/fathom_web/commands/histogram.py
@@ -7,21 +7,21 @@ from plotly.subplots import make_subplots
 
 @command()
 @argument('vector_file', type=File('r'))
-@option('--feature', '-f',
+@option('--feature_name', '-f',
         default='',
         help='The name of the feature to graph. Omit to graph all features.')
 @option('--show_zeros', '-z',
         is_flag=True,
         default=False,
         help='Show zero counts in the graphs. These tend to be large and dominate the scale of the graph, making it harder to see other bars.')
-def main(vector_file, feature, show_zeros):
+def main(vector_file, feature_name, show_zeros):
     """Print a histogram of one or more features."""
     data = load(vector_file)
     feature_names = data['header']['featureNames']
-    if feature:
-        feature_index = feature_names.index(feature)
+    if feature_name:
+        feature_index = feature_names.index(feature_name)
         vectors = [yes_and_no_vectors(data['pages'], feature_index, show_zeros)]
-        feature_names = [feature_names[feature_index]]
+        feature_names = [feature_name]
     else:
         vectors = [yes_and_no_vectors(data['pages'], feature_index, show_zeros)
                    for feature_index in range(len(feature_names))]

--- a/cli/fathom_web/commands/histogram.py
+++ b/cli/fathom_web/commands/histogram.py
@@ -7,26 +7,32 @@ from plotly.subplots import make_subplots
 
 @command()
 @argument('vector_file', type=File('r'))
-@option('feature', '-f',
-        type=str,
+@option('--feature', '-f',
         default='',
         help='The name of the feature to graph. Omit to graph all features.')
-def main(vector_file, feature):
+@option('--show_zeros', '-z',
+        is_flag=True,
+        default=False,
+        help='Show zero counts in the graphs. These tend to be large and dominate the scale of the graph, making it harder to see other bars.')
+def main(vector_file, feature, show_zeros):
     """Print a histogram of one or more features."""
     data = load(vector_file)
     feature_names = data['header']['featureNames']
     if feature:
         feature_index = feature_names.index(feature)
-        vectors = [yes_and_no_vectors(data['pages'], feature_index)]
+        vectors = [yes_and_no_vectors(data['pages'], feature_index, show_zeros)]
         feature_names = [feature_names[feature_index]]
     else:
-        vectors = [yes_and_no_vectors(data['pages'], feature_index)
+        vectors = [yes_and_no_vectors(data['pages'], feature_index, show_zeros)
                    for feature_index in range(len(feature_names))]
-    figure = histograms(vectors, feature_names)
+    figure = histograms(vectors,
+                        feature_names,
+                        'Histograms of Feature Values' + ('' if show_zeros else
+                                                          ', Zeros Omitted'))
     figure.show()
 
 
-def histograms(vectors, feature_names):
+def histograms(vectors, feature_names, title):
     """Return a figure containing a histogram for each feature."""
     COLS = 4
     rows = len(vectors) // COLS + (1 if len(vectors) % COLS else 0)
@@ -40,11 +46,13 @@ def histograms(vectors, feature_names):
         style = dict(nbinsx=100)
         figure.add_trace(Histogram(x=yes_vector,
                                    marker_color='green',
+                                   name='targets',
                                    **style),
                          row=row,
                          col=col)
         figure.add_trace(Histogram(x=no_vector,
                                    marker_color='red',
+                                   name='non-targets',
                                    **style),
                          row=row,
                          col=col)
@@ -54,11 +62,11 @@ def histograms(vectors, feature_names):
             row += 1
     figure.update_layout(barmode='stack',
                          showlegend=False,
-                         title_text='Histograms of Feature Values')
+                         title_text=title)
     return figure
 
 
-def yes_and_no_vectors(pages, feature_index):
+def yes_and_no_vectors(pages, feature_index, show_zeros):
     """For the specified feature, return a vector of feature values (across all
     pages) where the nodes are targets and another vector where the nodes are
     not targets."""
@@ -66,7 +74,7 @@ def yes_and_no_vectors(pages, feature_index):
     no_vector = []
     for page in pages:
         for node in page['nodes']:
-#            if node['features'][feature_index] != 0:
-            vector = yes_vector if node['isTarget'] else no_vector
-            vector.append(node['features'][feature_index])
+            if show_zeros or node['features'][feature_index] != 0:
+                vector = yes_vector if node['isTarget'] else no_vector
+                vector.append(node['features'][feature_index])
     return yes_vector, no_vector

--- a/cli/fathom_web/commands/histogram.py
+++ b/cli/fathom_web/commands/histogram.py
@@ -1,24 +1,50 @@
 from json import load
 
-from click import argument, command, File, option, progressbar
-from plotly.express import histogram
+from click import argument, command, File, option
+from plotly.graph_objects import Histogram
 from plotly.subplots import make_subplots
 
-from ..utils import classifier, tensor, tensors_from
+from ..utils import tensors_from
 
 
 @command()
 @argument('vector_file', type=File('r'))
-@argument('feature', type=str)
+@option('feature', '-f',
+        type=str,
+        default='',
+        help='The name of the feature to graph. Omit to graph all features.')
 def main(vector_file, feature):
-    """Print a histogram of the given feature."""
+    """Print a histogram of one or more features."""
     data = load(vector_file)
     x, y, num_yes = tensors_from(data['pages'])
+    feature_names = data['header']['featureNames']
+    if feature:
+        feature_index = feature_names.index(feature)
+        features = [values_for_feature(data['pages'], feature_index)]
+    else:
+        features = [values_for_feature(data['pages'], feature_index)
+                    for feature_index in range(len(feature_names))]
 
-    feature_index = data['header']['featureNames'].index(feature)
-    feature_values = []
-    for page in data['pages']:
-        for node in page['nodes']:
-            feature_values.append(node['features'][feature_index])
+    COLS = 4
+    rows = len(features) // COLS + (1 if len(features) % COLS else 0)
+    figure = make_subplots(
+        rows=rows,
+        cols=min(COLS, len(features)),
+        subplot_titles=feature_names[:len(features)]
+    )
+    row = col = 1
+    for f in features:
+        figure.add_trace(Histogram(name=feature, x=f, nbinsx=40),
+                         row=row,
+                         col=col)
+        col += 1
+        if col > COLS:
+            col = 1
+            row += 1
+    figure.show()
 
-    histogram({feature: feature_values}, x=feature, nbins=40).show()
+
+def values_for_feature(pages, feature_index):
+    return [node['features'][feature_index]
+            for page in pages
+            for node in page['nodes']]

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -18,6 +18,7 @@ setup(
     ],
     entry_points={'console_scripts': [
         'fathom-extract = fathom_web.commands.extract:main',
+        'fathom-histogram = fathom_web.commands.histogram:main',
         'fathom-label = fathom_web.commands.label:main',
         'fathom-list = fathom_web.commands.list:main',
         'fathom-pick = fathom_web.commands.pick:main',


### PR DESCRIPTION
In the course of trying to smarten up the trainer and obsolete semi-manual binarization (cutoffs), I graphed histograms of all the feature values so I could get a sense of what the data shape is (and whether I should try normal-curve bucketing vs. quantile, etc.). I wrote it for myself, as a research tool, but it might also come in handy to show the distribution of new feature values, to see if they're what you thought they were going to be. Feel free to review, but feel equally free to ignore until it's proven itself useful.

You're probably best off reviewing the complete diff all at once.

What I found on the Shopping ruleset is a superlinear falloff on almost all features. In retrospect, this should be unsurprising for features that are almost all counts of things.

![Screen Shot 2019-12-31 at 14 21 55 ](https://user-images.githubusercontent.com/295816/71631857-1c3ed980-2bd9-11ea-8277-bb33d7832d0b.png)

Btw, I don't think this actually has much overlap with Daniel's `rule_output_analysis.ipynb`.