### PR TITLE
Teach fathom-list how to optionally spit out original URLs of samples.

### DIFF
--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 from click import argument, command, File, option, Path
 
@@ -11,7 +12,9 @@ from click import argument, command, File, option, Path
         help='Recursively list files from the IN_DIRECTORY and all subdirectories.')
 @option('--out-file', '-o', type=File(mode='w'), default=None,
         help='A file for saving the printed filenames for easy future reference.')
-def main(in_directory, base_dir, recursive, out_file):
+@option('--show-urls', '-u', default=False, is_flag=True,
+        help='Also show the original URL of each sample.')
+def main(in_directory, base_dir, recursive, out_file, show_urls):
     """
     Lists relative paths of HTML files in a IN_DIRECTORY relative to BASE_DIR, one filename per line.
     If BASE_DIR is not specified, paths are relative to IN_DIRECTORY. Optionally saves output to OUT_FILE.
@@ -36,7 +39,11 @@ def main(in_directory, base_dir, recursive, out_file):
     for file in path_iterator:
         there_were_no_files = False
         relative_path = file.relative_to(base_dir)
-        print(relative_path)
+        if show_urls:
+            with file.open() as open_file:
+                print(relative_path, original_url(open_file))
+        else:
+            print(relative_path)
 
         if out_file is not None:
             filenames_to_save.append(relative_path.as_posix() + '\n')
@@ -46,3 +53,14 @@ def main(in_directory, base_dir, recursive, out_file):
             print(f'No .html files found in {in_directory}. Did not create {out_file.name}.')
         else:
             out_file.writelines(filenames_to_save)
+
+
+def original_url(open_file):
+    """Return the original URL that FathomFox embedded in a given sample."""
+    # I started to write a clever loop to read only as much from each file as
+    # we needed, but it turns out reading 67 entire unextracted samples takes
+    # only 1.2s on my laptop.
+    match = re.search('<link rel="original" href="([^"]+)">', open_file.read())
+    if not match:
+        return ''
+    return match.group(1)


### PR DESCRIPTION
I needed this a second time, so I guess it's time to make it publicly available!

Specifically, I'm using it to tell which domains were assigned to Vlad and actually yielded a sample, so I don't assign him the same domain a second time.