### PR TITLE
Drop Python 3.6 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ jobs:
       after_success:
         - make coveralls
     - stage: test
-      name: "Python 3.6 tests"
-      language: python
-      python:
-        - "3.6"
-      script:
-        - make py_test
-    - stage: test
       name: "Python 3.7 tests"
       dist: bionic
       language: python


### PR DESCRIPTION
I think we were testing it because one of us was running it. I don't think we are anymore. And besides, 3.8 is out.