### PR TITLE
Add `againstElement()`, which lets us efficiently classify only a single element.

### DIFF
--- a/docs/ruleset.rst
+++ b/docs/ruleset.rst
@@ -10,7 +10,7 @@ The top-level Fathom object is the ruleset, an unordered collection of rules. Th
 .. autofunction:: ruleset
 
 .. autoclass:: Ruleset
-   :members: against, againstElement, rules
+   :members: against, rules
 
 Then you call :func:`Ruleset.against` to get back a :class:`BoundRuleset`, which is specific to a given DOM tree. From that, you pull answers.
 

--- a/docs/ruleset.rst
+++ b/docs/ruleset.rst
@@ -10,7 +10,7 @@ The top-level Fathom object is the ruleset, an unordered collection of rules. Th
 .. autofunction:: ruleset
 
 .. autoclass:: Ruleset
-   :members: against, rules
+   :members: against, againstElement, rules
 
 Then you call :func:`Ruleset.against` to get back a :class:`BoundRuleset`, which is specific to a given DOM tree. From that, you pull answers.
 

--- a/index.mjs
+++ b/index.mjs
@@ -5,7 +5,7 @@
 const version = '3.2.1';
 import {rule} from './rule';
 import {ruleset} from './ruleset';
-import {dom} from './lhs';
+import {dom, element} from './lhs';
 import {out} from './rhs';
 import {and, atMost, nearest, note, props, score, type, typeIn} from './side';
 
@@ -15,6 +15,7 @@ export {
     and,
     atMost,
     dom,
+    element,
     nearest,
     note,
     out,

--- a/lhs.mjs
+++ b/lhs.mjs
@@ -8,14 +8,26 @@ import {maxes, getDefault, max, NiceSet, setDefault, sum, min} from './utilsForF
  * Take nodes that match a given DOM selector. Example:
  * ``dom('meta[property="og:title"]')``
  *
- * Every ruleset has at least one ``dom`` rule, as that is where nodes begin to
- * flow into the system. If run against a subtree of a document, the root of
- * the subtree is not considered as a possible match.
+ * Every ruleset has at least one ``dom`` or :func:`element` rule, as that is
+ * where nodes begin to flow into the system. If run against a subtree of a
+ * document, the root of the subtree is not considered as a possible match.
  */
 export function dom(selector) {
     return new DomLhs(selector);
 }
 
+/**
+ * Take a single given node if it matches a given DOM selector, without looking
+ * through its descendents or ancestors. Otherwise, take no nodes. Example:
+ * ``element(someNodeTheUserClicked)``
+ *
+ * This is useful for applications in which you want Fathom to classify an
+ * element the user has selected, rather than scanning the whole page for
+ * candidates.
+ */
+export function element(selector) {
+    return new ElementLhs(selector);
+}
 
 /**
  * Rules and the LHSs and RHSs that comprise them have no mutable state. This
@@ -150,9 +162,16 @@ class DomLhs extends Lhs {
     constructor(selector) {
         super();
         if (selector === undefined) {
-            throw new Error('A querySelector()-style selector is required as the argument to dom().');
+            throw new Error('A querySelector()-style selector is required as the argument to ' + this._callName() + '().');
         }
         this.selector = selector;
+    }
+
+    /**
+     * Return the name of this kind of LHS, for use in error messages.
+     */
+    _callName() {
+        return 'dom';
     }
 
     clone() {
@@ -160,22 +179,26 @@ class DomLhs extends Lhs {
     }
 
     fnodes(ruleset) {
-        const ret = [];
-        let matches;
-        if (ruleset.matchesOneElementOnly) {
-            matches = ruleset.doc.matches(this.selector) ? [ruleset.doc] : [];
-        } else {
-            matches = ruleset.doc.querySelectorAll(this.selector);
-        }
-        for (let i = 0; i < matches.length; i++) {
-            ret.push(ruleset.fnodeForElement(matches[i]));
+        return this._domNodesToFilteredFnodes(
+            ruleset,
+            ruleset.doc.querySelectorAll(this.selector));
+    }
+
+    /**
+     * Turn a NodeList of DOM nodes into an array of fnodes, and filter out
+     * those that don't match the :func:`when()` clause.
+     */
+    _domNodesToFilteredFnodes(ruleset, domNodes) {
+        let ret = [];
+        for (let i = 0; i < domNodes.length; i++) {
+            ret.push(ruleset.fnodeForElement(domNodes[i]));
         }
         return super.fnodesSatisfyingWhen(ret);
     }
 
     checkFact(fact) {
         if (fact.type === undefined) {
-            throw new Error(`The right-hand side of a dom() rule failed to specify a type. This means there is no way for its output to be used by later rules. All it specified was ${fact}.`);
+            throw new Error(`The right-hand side of a ${this._callName()}() rule failed to specify a type. This means there is no way for its output to be used by later rules. All it specified was ${fact}.`);
         }
     }
 
@@ -189,6 +212,18 @@ class DomLhs extends Lhs {
 
     typesMentioned() {
         return new NiceSet();
+    }
+}
+
+class ElementLhs extends DomLhs {
+    _callName() {
+        return 'element';
+    }
+
+    fnodes(ruleset) {
+        return this._domNodesToFilteredFnodes(
+            ruleset,
+            ruleset.doc.matches(this.selector) ? [ruleset.doc] : []);
     }
 }
 

--- a/lhs.mjs
+++ b/lhs.mjs
@@ -9,7 +9,8 @@ import {maxes, getDefault, max, NiceSet, setDefault, sum, min} from './utilsForF
  * ``dom('meta[property="og:title"]')``
  *
  * Every ruleset has at least one ``dom`` rule, as that is where nodes begin to
- * flow into the system.
+ * flow into the system. If run against a subtree of a document, the root of
+ * the subtree is not considered as a possible match.
  */
 export function dom(selector) {
     return new DomLhs(selector);
@@ -160,7 +161,12 @@ class DomLhs extends Lhs {
 
     fnodes(ruleset) {
         const ret = [];
-        const matches = ruleset.doc.querySelectorAll(this.selector);
+        let matches;
+        if (ruleset.matchesOneElementOnly) {
+            matches = ruleset.doc.matches(this.selector) ? [ruleset.doc] : [];
+        } else {
+            matches = ruleset.doc.querySelectorAll(this.selector);
+        }
         for (let i = 0; i < matches.length; i++) {
             ret.push(ruleset.fnodeForElement(matches[i]));
         }

--- a/ruleset.mjs
+++ b/ruleset.mjs
@@ -78,29 +78,7 @@ class Ruleset {
                                 this._rulesThatCouldEmit,
                                 this._rulesThatCouldAdd,
                                 this._coeffs,
-                                this.biases,
-                                false);
-    }
-
-    /**
-     * Commit this ruleset to running against a single DOM element, without
-     * looking through its descendents or ancestors.
-     *
-     * This is useful for applications in which you want Fathom to classify an
-     * element the user has selected, rather than scanning the whole page for
-     * candidates.
-     *
-     * Like :func:`against`, this returns a new :class:`BoundRuleset`.
-     */
-    againstElement(element) {
-        return new BoundRuleset(element,
-                                this._inRules,
-                                this._outRules,
-                                this._rulesThatCouldEmit,
-                                this._rulesThatCouldAdd,
-                                this._coeffs,
-                                this.biases,
-                                true);
+                                this.biases);
     }
 
     /**
@@ -125,7 +103,7 @@ class BoundRuleset {
      * @arg inRules {Array} Non-out() rules
      * @arg outRules {Map} Output key -> out() rule
      */
-    constructor(doc, inRules, outRules, rulesThatCouldEmit, rulesThatCouldAdd, coeffs, biases, matchesOneElementOnly) {
+    constructor(doc, inRules, outRules, rulesThatCouldEmit, rulesThatCouldAdd, coeffs, biases) {
         this.doc = doc;
         this._inRules = inRules;
         this._outRules = outRules;
@@ -138,7 +116,6 @@ class BoundRuleset {
         this._clearCaches();
         this.elementCache = new WeakMap();  // DOM element => fnode about it
         this.doneRules = new Set();  // InwardRules that have been executed. OutwardRules can be executed more than once because they don't change any fnodes and are thus idempotent.
-        this.matchesOneElementOnly = matchesOneElementOnly;
     }
 
     /**

--- a/ruleset.mjs
+++ b/ruleset.mjs
@@ -62,10 +62,13 @@ class Ruleset {
     }
 
     /**
-     * Commit this ruleset to running against a specific DOM tree.
+     * Commit this ruleset to running against a specific DOM tree or subtree.
+     *
+     * When run against a subtree, the root of the subtree is not considered as
+     * a possible match.
      *
      * This doesn't actually modify the Ruleset but rather returns a fresh
-     * BoundRuleset, which contains caches and other stateful, per-DOM
+     * :class:`BoundRuleset`, which contains caches and other stateful, per-DOM
      * bric-a-brac.
      */
     against(doc) {
@@ -75,7 +78,29 @@ class Ruleset {
                                 this._rulesThatCouldEmit,
                                 this._rulesThatCouldAdd,
                                 this._coeffs,
-                                this.biases);
+                                this.biases,
+                                false);
+    }
+
+    /**
+     * Commit this ruleset to running against a single DOM element, without
+     * looking through its descendents or ancestors.
+     *
+     * This is useful for applications in which you want Fathom to classify an
+     * element the user has selected, rather than scanning the whole page for
+     * candidates.
+     *
+     * Like :func:`against`, this returns a new :class:`BoundRuleset`.
+     */
+    againstElement(element) {
+        return new BoundRuleset(element,
+                                this._inRules,
+                                this._outRules,
+                                this._rulesThatCouldEmit,
+                                this._rulesThatCouldAdd,
+                                this._coeffs,
+                                this.biases,
+                                true);
     }
 
     /**
@@ -93,14 +118,14 @@ class Ruleset {
  * A ruleset that is earmarked to analyze a certain DOM
  *
  * Carries a cache of rule results on that DOM. Typically comes from
- * :func:`Ruleset.against`.
+ * :func:`against`.
  */
 class BoundRuleset {
     /**
      * @arg inRules {Array} Non-out() rules
      * @arg outRules {Map} Output key -> out() rule
      */
-    constructor(doc, inRules, outRules, rulesThatCouldEmit, rulesThatCouldAdd, coeffs, biases) {
+    constructor(doc, inRules, outRules, rulesThatCouldEmit, rulesThatCouldAdd, coeffs, biases, matchesOneElementOnly) {
         this.doc = doc;
         this._inRules = inRules;
         this._outRules = outRules;
@@ -113,6 +138,7 @@ class BoundRuleset {
         this._clearCaches();
         this.elementCache = new WeakMap();  // DOM element => fnode about it
         this.doneRules = new Set();  // InwardRules that have been executed. OutwardRules can be executed more than once because they don't change any fnodes and are thus idempotent.
+        this.matchesOneElementOnly = matchesOneElementOnly;
     }
 
     /**

--- a/test/ruleset_tests.mjs
+++ b/test/ruleset_tests.mjs
@@ -287,6 +287,37 @@ describe('Ruleset', function () {
         assert.equal(subtreeBest[0].element.id, 'inner');
     });
 
+    describe('evaluates a single element', function () {
+        it('without going inside or outside it', function () {
+            const doc = staticDom(`
+                <div id=root class=target>some text
+                    <div id=middle class=target>
+                        <div id=inner class=target></div>
+                    </div>
+                </div>
+            `);
+            const rules = ruleset([
+                rule(dom('.target'), type('smoo'))
+            ]);
+            const subtree = doc.getElementById('middle');
+            const facts = rules.againstElement(subtree);
+            const fnodes = facts.get(type('smoo'));
+            assert.equal(fnodes.length, 1);
+            assert.equal(fnodes[0].element.id, 'middle');
+        });
+
+        it('negatively', function () {
+            const doc = staticDom(`
+                <div id=thing class=target></div>
+            `);
+            const rules = ruleset([
+                rule(dom('.tarrrrrrrget'), type('smoo'))
+            ]);
+            const subtree = doc.getElementById('thing');
+            assert.equal(rules.againstElement(subtree).get(type('smoo')).length, 0);
+        });
+    });
+
     it('adjusts coeffs and biases after construction', function () {
         const doc = staticDom(`
         `);

--- a/test/ruleset_tests.mjs
+++ b/test/ruleset_tests.mjs
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 
 import {distance} from '../clusters';
-import {and, dom, nearest, props, rule, ruleset, score, type} from '../index';
+import {and, dom, element, nearest, props, rule, ruleset, score, type} from '../index';
 import {domSort, sigmoid, staticDom} from '../utils';
 
 
@@ -297,10 +297,10 @@ describe('Ruleset', function () {
                 </div>
             `);
             const rules = ruleset([
-                rule(dom('.target'), type('smoo'))
+                rule(element('.target'), type('smoo'))
             ]);
             const subtree = doc.getElementById('middle');
-            const facts = rules.againstElement(subtree);
+            const facts = rules.against(subtree);
             const fnodes = facts.get(type('smoo'));
             assert.equal(fnodes.length, 1);
             assert.equal(fnodes[0].element.id, 'middle');
@@ -311,10 +311,10 @@ describe('Ruleset', function () {
                 <div id=thing class=target></div>
             `);
             const rules = ruleset([
-                rule(dom('.tarrrrrrrget'), type('smoo'))
+                rule(element('.tarrrrrrrget'), type('smoo'))
             ]);
             const subtree = doc.getElementById('thing');
-            assert.equal(rules.againstElement(subtree).get(type('smoo')).length, 0);
+            assert.equal(rules.against(subtree).get(type('smoo')).length, 0);
         });
     });
 


### PR DESCRIPTION
Considered making a workalike to `dom()` called `element()` or `one()` (and aliasing `dom()` to `all()`), but then you'd need to change a ruleset every time you wanted to use it differently. That should be the application's decision, not the ruleset writer's. And, of immediate practical value, any ruleset using `element()` in production would need a clumsy switch to use `dom()` in training.