### PR TITLE
Tells the trainer to use assume a utf-8 encoding for vector files.

### DIFF
--- a/cli/fathom_web/commands/train.py
+++ b/cli/fathom_web/commands/train.py
@@ -100,9 +100,9 @@ def exclude_features(exclude, vector_data):
 
 @command()
 @argument('training_file',
-          type=File('r'))
+          type=File('r', encoding='utf-8'))
 @option('validation_file', '-a',
-        type=File('r'),
+        type=File('r', encoding='utf-8'),
         help="A file of validation samples from FathomFox's Vectorizer, used to graph validation loss so you can see when you start to overfit")
 @option('--stop-early', '-s',
         default=False,


### PR DESCRIPTION
Without doing this, the vector files are opened with the CP1252 encoding on Windows, and the trainer will not work.