### PR TITLE
Use an in-project venv for cli every time. Fix #225.

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,20 +1,21 @@
 # We avoid $(CURDIR) because it spits out /cygdrive/c/... on Windows Cygwin
 # installs and leads to things that don't work.
-VIRTUAL_ENV ?= ./venv
+VIRTUAL_ENV = ./venv
 PYTHON3 ?= python3
-PATH := $(VIRTUAL_ENV)/bin:$(VIRTUAL_ENV)/Scripts:$(PATH)
+# PATH seems to be exported even without "export", but I kept it to be explicit.
+export PATH := $(VIRTUAL_ENV)/bin:$(VIRTUAL_ENV)/Scripts:$(PATH)
 
 release: venv
-	python setup.py sdist bdist_wheel
+	PATH=$(PATH) python setup.py sdist bdist_wheel
 
 lint: venv
-	@flake8 --exclude $(VIRTUAL_ENV) .
+	@PATH=$(PATH) flake8 --exclude $(VIRTUAL_ENV) .
 
 test: venv
-	@pytest fathom_web/test
+	@PATH=$(PATH) pytest fathom_web/test
 
 clean:
-	rm -rf venv  # Don't delete a venv outside our folder.
+	rm -rf $(VIRTUAL_ENV)
 
 venv: $(VIRTUAL_ENV)/pyvenv.cfg
 
@@ -25,8 +26,10 @@ venv: $(VIRTUAL_ENV)/pyvenv.cfg
 # changed. Install the dev requirements and the actual requirements.
 $(VIRTUAL_ENV)/pyvenv.cfg: dev-requirements.txt setup.py
 	$(PYTHON3) -m venv $(VIRTUAL_ENV)
-	pip3 install -r dev-requirements.txt
-	pip3 install -e . -f https://download.pytorch.org/whl/torch_stable.html
+	# We don't path-qualify pip3 because python -m venv on Travis creates a
+	# venv with no pip executable in it.
+	PATH=$(PATH) pip3 install -r dev-requirements.txt
+	PATH=$(PATH) pip3 install -e . -f https://download.pytorch.org/whl/torch_stable.html
 
 
 .PHONY: release lint test clean venv

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,10 +1,10 @@
 # We avoid $(CURDIR) because it spits out /cygdrive/c/... on Windows Cygwin
 # installs and leads to things that don't work.
-VIRTUAL_ENV ?= venv
+VIRTUAL_ENV = ./venv
 PYTHON3 ?= python3
 
 # Let us find jsdoc and sphinx:
-PATH := ../fathom/node_modules/.bin:$(VIRTUAL_ENV)/bin:$(VIRTUAL_ENV)/Scripts:$(PATH)
+export PATH := ../fathom/node_modules/.bin:$(VIRTUAL_ENV)/bin:$(VIRTUAL_ENV)/Scripts:$(PATH)
 
 # Generate .js files from .mjs so jsdoc can parse them, and install jsdoc:
 .PHONY: js
@@ -18,7 +18,7 @@ venv: $(VIRTUAL_ENV)/pyvenv.cfg
 # changed. Install the doc-building requirements.
 $(VIRTUAL_ENV)/pyvenv.cfg: doc-building-requirements.txt
 	$(PYTHON3) -m venv $(VIRTUAL_ENV)
-	pip3 install -r doc-building-requirements.txt
+	PATH=$(PATH) pip3 install -r doc-building-requirements.txt
 
 
 # --------- The rest of this is from the stock Sphinx makefile: -----------
@@ -74,7 +74,7 @@ docs_clean:
 
 .PHONY: clean
 clean: docs_clean
-	rm -rf venv  # Don't delete a venv outside our folder.
+	rm -rf $(VIRTUAL_ENV)
 
 .PHONY: html
 html: js venv


### PR DESCRIPTION
Calling just `pytest` doesn't appear to find the correct pytest, even when PATH is explicitly exported. (I deduce this from the fact that it doesn't see the libs installed in the venv.) However, executing a shell script that prints out $PATH shows that PATH did get passed down to the subshell. If I explicitly set the env var PATH, it works.