### PR TITLE
Adds changes needed to get vectorization to "work" on Windows.

### DIFF
--- a/cli/fathom_web/vectorizer.py
+++ b/cli/fathom_web/vectorizer.py
@@ -194,7 +194,7 @@ def fathom_fox_addon(ruleset_file):
 
 def add_cmd_if_windows(binary_path):
     """Add the .cmd suffix to a pathlib.Path if running on Windows."""
-    if platform.system() == 'Windows':
+    if os.name == 'nt':
         return binary_path.with_suffix('.cmd')
     else:
         return binary_path
@@ -284,12 +284,14 @@ def locked_cached_fathom():
             # Install yarn, because it installs FathomFox's dependencies in 15s rather
             # than 30s. And once installed once, yarn itself takes only 1.5s to install
             # again. Also, it has security advantages. Though this install itself isn't
-            # hashed, so we're just trusting NPM.
+            # hashed, so we're just trusting NPM. Additionally, we have to call
+            # shutils.which() on npm because it is a .cmd file on Windows, while node
+            # (down below) is an executable.
             run_in_fathom_fox(which('npm'), 'install', 'yarn@1.22.4',
                               desc='Installing yarn')
 
             # Figure out how to invoke yarn:
-            if platform.system() == 'Windows':
+            if os.name == 'nt':
                 yarn_binary = str((fathom_fox / 'node_modules' / 'yarn' / 'bin' / 'yarn.js').resolve())
             else:
                 yarn_binary = str((fathom_fox / 'node_modules' / '.bin' / 'yarn').resolve())

--- a/cli/fathom_web/vectorizer.py
+++ b/cli/fathom_web/vectorizer.py
@@ -174,11 +174,7 @@ def fathom_fox_addon(ruleset_file):
                 copyfileobj(ruleset_file, new_ruleset_file)
 
             # Build FathomFox:
-            if platform.system() == 'Windows':
-                rollup_path = str((fathom_fox / 'node_modules' / '.bin' / 'rollup.cmd').resolve())
-            else:
-                rollup_path = str((fathom_fox / 'node_modules' / '.bin' / 'rollup').resolve())
-            run(rollup_path,
+            run(str(add_cmd_if_windows((fathom_fox / 'node_modules' / '.bin' / 'rollup').resolve())),
                 '-c',
                 cwd=fathom_fox,
                 desc='Compiling ruleset')
@@ -193,11 +189,15 @@ def fathom_fox_addon(ruleset_file):
         # It should be okay to reference geckodriver outside the
         # locked_cached_fathom() lock, since that part of the cache is
         # immutable:
-        if platform.system() == 'Windows':
-            geckodriver_path = (fathom_fox / 'node_modules' / '.bin' / 'geckodriver.cmd')
-        else:
-            geckodriver_path = (fathom_fox / 'node_modules' / '.bin' / 'geckodriver')
-        yield addon_path, geckodriver_path
+        yield addon_path, add_cmd_if_windows(fathom_fox / 'node_modules' / '.bin' / 'geckodriver')
+
+
+def add_cmd_if_windows(binary_path):
+    """Add the .cmd suffix to a pathlib.Path if running on Windows."""
+    if platform.system() == 'Windows':
+        return binary_path.with_suffix('.cmd')
+    else:
+        return binary_path
 
 
 def remove_old_fathom_caches(source_cache, current_hash):

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -69,37 +69,37 @@ clean:
 
 .PHONY: html
 html: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	PATH="$(PATH)" $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
 dirhtml: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	PATH="$(PATH)" $(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
 singlehtml: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
+	PATH="$(PATH)" $(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: pickle
 pickle: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
+	PATH="$(PATH)" $(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
 .PHONY: json
 json: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
+	PATH="$(PATH)" $(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
 .PHONY: htmlhelp
 htmlhelp: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
+	PATH="$(PATH)" $(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
@@ -116,7 +116,7 @@ qthelp: js venv
 
 .PHONY: applehelp
 applehelp: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
+	PATH="$(PATH)" $(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
 	@echo "N.B. You won't be able to view it unless you put it in" \
@@ -125,7 +125,7 @@ applehelp: js venv
 
 .PHONY: devhelp
 devhelp: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
+	PATH="$(PATH)" $(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
@@ -135,19 +135,19 @@ devhelp: js venv
 
 .PHONY: epub
 epub: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	PATH="$(PATH)" $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
 .PHONY: epub3
 epub3: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3
+	PATH="$(PATH)" $(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3
 	@echo
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
 latex: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	PATH="$(PATH)" $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
@@ -155,33 +155,33 @@ latex: js venv
 
 .PHONY: latexpdf
 latexpdf: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	PATH="$(PATH)" $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: latexpdfja
 latexpdfja: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
+	PATH="$(PATH)" $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: text
 text: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
+	PATH="$(PATH)" $(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 .PHONY: man
 man: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
+	PATH="$(PATH)" $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
 .PHONY: texinfo
 texinfo: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	PATH="$(PATH)" $(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
@@ -189,56 +189,56 @@ texinfo: js venv
 
 .PHONY: info
 info: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
+	PATH="$(PATH)" $(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
 .PHONY: gettext
 gettext: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
+	PATH="$(PATH)" $(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
 .PHONY: changes
 changes: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
+	PATH="$(PATH)" $(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 .PHONY: linkcheck
 linkcheck: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+	PATH="$(PATH)" $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 .PHONY: doctest
 doctest: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
+	PATH="$(PATH)" $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 .PHONY: coverage
 coverage: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
+	PATH="$(PATH)" $(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
 .PHONY: xml
 xml: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
+	PATH="$(PATH)" $(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
 .PHONY: pseudoxml
 pseudoxml: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
+	PATH="$(PATH)" $(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 .PHONY: dummy
 dummy: js venv
-	PATH=$(PATH) $(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
+	PATH="$(PATH)" $(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
 	@echo
 	@echo "Build finished. Dummy builder generates no files."


### PR DESCRIPTION
 I do run into an error every time during vectorization though. Regardless of how many samples, threads, delay, I always hit a `Error: can't access property "browser", tab is null` during vectorization. I don't think I've hit this before. I want to get this over to @erikrose to see if the changes I made to get autovec working on Windows cause the same problems on Mac.