### PR TITLE
Combine Fathom commands into a single one. Close #233.

### DIFF
--- a/cli/fathom_web/commands/__init__.py
+++ b/cli/fathom_web/commands/__init__.py
@@ -1,0 +1,27 @@
+from .extract import extract
+from .fox import fox
+from .histogram import histogram
+from .label import label
+from .list import list
+from .pick import pick
+from .serve import serve
+from .test import test
+from .train import train
+
+from click import group
+
+
+@group()
+def fathom():
+    """Pass fathom COMMAND --help to learn more about an individual command."""
+
+
+fathom.add_command(extract)
+fathom.add_command(fox)
+fathom.add_command(histogram)
+fathom.add_command(label)
+fathom.add_command(list)
+fathom.add_command(pick)
+fathom.add_command(serve)
+fathom.add_command(test)
+fathom.add_command(train)

--- a/cli/fathom_web/commands/extract.py
+++ b/cli/fathom_web/commands/extract.py
@@ -63,14 +63,16 @@ MIME_TYPE_TO_FILE_EXTENSION = {
         help='Save original HTML files in a newly created `originals`'
              ' directory in IN_DIRECTORY (default: True)')
 @argument('in_directory', type=Path(exists=True, file_okay=False))
-def main(in_directory, preserve_originals):
+def extract(in_directory, preserve_originals):
     """
-    Extract resources from the HTML pages in IN_DIRECTORY and store the
-    resources for each page in a newly created page-specific directory
-    within a newly created resources directory in IN_DIRECTORY.
-    For example, the resources for ``example.html`` would be stored in
-    ``resources/example/``. This tool is used to prepare your samples for a
-    git-LFS-enabled repository.
+    Extract resources from samples to store them in Git LFS.
+
+    Extract resources from the HTML pages in IN_DIRECTORY, and store the
+    resources for each page in a newly created page-specific directory within a
+    newly created resources directory in IN_DIRECTORY. For example, the
+    resources for ``example.html`` would be stored in ``resources/example/``.
+    This tool is used to prepare your samples for a git-LFS-enabled repository.
+
     """
     if preserve_originals:
         originals_dir = pathlib.Path(in_directory) / 'originals'

--- a/cli/fathom_web/commands/fox.py
+++ b/cli/fathom_web/commands/fox.py
@@ -13,11 +13,12 @@ from ..vectorizer import fathom_fox_addon, fathom_zip, running_firefox
         type=click.Path(exists=True, dir_okay=False, resolve_path=True),
         callback=path_or_none,
         help='The rulesets.js file containing your rules. The file must have no imports except from fathom-web, so pre-bundle if necessary. [default: the demo ruleset included with FathomFox]')
-def main(ruleset):
-    """Launch a fresh instance of Firefox with a blank profile and FathomFox
-    installed.
+def fox(ruleset):
+    """
+    Launch Firefox with FathomFox installed.
 
-    This is an easy way to set up an environment for labeling samples.
+    This launches a fresh instance of Firefox with a blank profile as a
+    suitably clean environment for labeling samples.
 
     """
     with ruleset_or_default(ruleset) as ruleset_file:

--- a/cli/fathom_web/commands/histogram.py
+++ b/cli/fathom_web/commands/histogram.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 from click import argument, BadOptionUsage, command, get_terminal_size, option, style
 from more_itertools import pairwise
-from numpy import histogram
+import numpy
 
 from ..utils import path_or_none, tensors_from
 from ..vectorizer import make_or_find_vectors
@@ -49,12 +49,12 @@ from ..vectorizer import make_or_find_vectors
         type=str,
         multiple=True,
         help='The rule to graph. Can be repeated. Omitting this graphs all rules.')
-def main(training_set, ruleset, trainee, training_cache, delay, tabs, show_browser, buckets, rules):
-    """Print a histogram of rule scores, showing what proportion at each
-    score was a positive or negative sample.
+def histogram(training_set, ruleset, trainee, training_cache, delay, tabs, show_browser, buckets, rules):
+    """Show a histogram of rule scores.
 
-    This gives you an idea whether a rule is broadly applicable,
-    discriminatory, and spitting out what you expect.
+    We also break down what proportion of each bucket comprised positive or
+    negative samples. Altogether, this gives you an idea whether a rule is
+    broadly applicable, discriminatory, and spitting out what you expect.
 
     """
     training_set = Path(training_set)
@@ -85,8 +85,8 @@ def feature_metrics(feature_names, x, y, buckets, enabled_rules):
         if name not in enabled_rules:
             continue
         is_boolean = is_boolean_feature(values)
-        _, boundaries = histogram(values.numpy(),
-                                  bins=2 if is_boolean else buckets)
+        _, boundaries = numpy.histogram(values.numpy(),
+                                        bins=2 if is_boolean else buckets)
         highest_boundary = boundaries[-1]
         bars = []
         for boundary, (low_bound, high_bound) in zip(boundaries, pairwise(boundaries)):

--- a/cli/fathom_web/commands/label.py
+++ b/cli/fathom_web/commands/label.py
@@ -19,12 +19,15 @@ from click import argument, command, option, Path, progressbar, STRING
              ' process (default: the number of logical cores the machine has)')
 @argument('in_directory', type=Path(exists=True, file_okay=False))
 @argument('in_type', type=STRING)
-def main(in_directory, in_type, preserve_originals, number_of_workers):
+def label(in_directory, in_type, preserve_originals, number_of_workers):
     """
+    Apply a whole-page label to each page in a directory.
+
     Add the ``data-fathom`` attribute with a value of IN_TYPE to the
     opening tag of any ``<html>`` elements in the HTML pages in
     IN_DIRECTORY. This tool is used to label an entire webpage (e.g.
     IN_TYPE could be "article" for article webpages).
+
     """
     if preserve_originals:
         originals_dir = pathlib.Path(in_directory) / 'originals'

--- a/cli/fathom_web/commands/list.py
+++ b/cli/fathom_web/commands/list.py
@@ -13,8 +13,10 @@ from ..utils import samples_from_dir
         help='A file for saving the printed filenames for easy future reference.')
 @option('--show-urls', '-u', default=False, is_flag=True,
         help='Also show the original URL of each sample.')
-def main(in_directory, base_dir, out_file, show_urls):
+def list(in_directory, base_dir, out_file, show_urls):
     """
+    List URL paths to samples.
+
     Recursively list paths of HTML files in IN_DIRECTORY relative to
     <base_dir>, one path per line. If <base_dir> is not specified,
     paths are relative to IN_DIRECTORY. Optionally saves output to
@@ -22,7 +24,7 @@ def main(in_directory, base_dir, out_file, show_urls):
 
     This is useful for vectorizing samples using FathomFox. FathomFox expects
     input filenames copied into a text box with one filename per line and
-    relative to some path you are serving files from using fathom-serve.
+    relative to some path you are serving files from using ``fathom serve``.
 
     """
     if base_dir is None:

--- a/cli/fathom_web/commands/pick.py
+++ b/cli/fathom_web/commands/pick.py
@@ -11,12 +11,12 @@ from click import argument, command, Path, UsageError
 @argument('to_dir',
           type=Path(exists=True, file_okay=False, writable=True, dir_okay=True))
 @argument('number', type=int)
-def main(from_dir, to_dir, number):
-    """Move a random selection of HTML files and their extracted resources, if
-    any, from one directory to another. Ignore hidden files.
+def pick(from_dir, to_dir, number):
+    """
+    Randomly move samples to a training, validation, or test set.
 
-    This is useful for dividing a corpus into training, validation, and testing
-    sets.
+    Move a random selection of HTML files and their extracted resources, if
+    any, from one directory to another. Ignore hidden files.
 
     """
     # Make these strings into ``Path``s so they are easier to work with

--- a/cli/fathom_web/commands/serve.py
+++ b/cli/fathom_web/commands/serve.py
@@ -10,14 +10,14 @@ from click import command, option, Path
         help='The port to use (default: 8000)')
 @option('--directory', '-d', type=Path(exists=True, file_okay=False), default=os.getcwd(),
         help='The directory to serve files from (default: current working directory)')
-def main(directory, port):
+def serve(directory, port):
     """
-    Serve the files in <directory> over a local HTTP server:
-    http://localhost:<port>.
+    Serve samples locally over HTTP.
 
-    This is useful for vectorizing samples using FathomFox. FathomFox expects
-    you to provide, in the vectorizer page, an address to an HTTP server that
-    is serving your samples.
+    Serve the files in <directory> at http://localhost:<port>. This is useful
+    for vectorizing samples using FathomFox. FathomFox expects you to provide,
+    in the vectorizer page, an address to an HTTP server that is serving your
+    samples.
 
     """
     server = ThreadingHTTPServer(('localhost', port), partial(SimpleHTTPRequestHandler, directory=directory))

--- a/cli/fathom_web/commands/test.py
+++ b/cli/fathom_web/commands/test.py
@@ -86,16 +86,16 @@ def model_from_json(weights, num_outputs, feature_names):
         default=False,
         is_flag=True,
         help='Show per-tag diagnostics, even though that could ruin blinding for the test set.')
-def main(testing_set, weights, confidence_threshold, ruleset, trainee, testing_cache, delay, tabs, show_browser, verbose):
-    """Compute the accuracy of the given coefficients and biases on a folder of
-    testing samples.
+def test(testing_set, weights, confidence_threshold, ruleset, trainee, testing_cache, delay, tabs, show_browser, verbose):
+    """
+    Evaluate how well a trained ruleset does.
 
     TESTING_SET_FOLDER is a directory of labeled testing pages. It can also be,
     for backward compatibility, a JSON file of vectors from FathomFox's
     Vectorizer.
 
-    WEIGHTS should be a JSON-formatted object like this. You can paste it
-    directly from the output of fathom-train.
+    WEIGHTS should be a JSON-formatted object, as follows. You can paste it
+    directly from the output of trainer.
 
     \b
         {"coeffs": [["nextAnchorIsJavaScript", 1.1627885103225708],

--- a/cli/fathom_web/commands/train.py
+++ b/cli/fathom_web/commands/train.py
@@ -179,12 +179,12 @@ def exclude_features(exclude, vector_data):
         type=str,
         multiple=True,
         help='Exclude a rule while training. This helps with before-and-after tests to see if a rule is effective.')
-def main(training_set, validation_set, ruleset, trainee, training_cache, validation_cache, delay, tabs, show_browser, stop_early, learning_rate, iterations, pos_weight, comment, quiet, confidence_threshold, layers, exclude):
+def train(training_set, validation_set, ruleset, trainee, training_cache, validation_cache, delay, tabs, show_browser, stop_early, learning_rate, iterations, pos_weight, comment, quiet, confidence_threshold, layers, exclude):
     """Compute optimal numerical parameters for a Fathom ruleset.
 
     The usual invocation is something like this::
 
-        fathom-train samples/training --validation-set samples/validation --ruleset rulesets.js --trainee new
+        fathom train samples/training --validation-set samples/validation --ruleset rulesets.js --trainee new
 
     The first argument is a directory of labeled training pages. It can also
     be, for backward compatibility, a JSON file of vectors from FathomFox's

--- a/cli/fathom_web/test/test_extract.py
+++ b/cli/fathom_web/test/test_extract.py
@@ -16,7 +16,7 @@ def get_base64_regex_matches(from_string):
     """Helper method to get the list of matches from the given string.
 
     We need to use finditer() here because it returns Match objects while
-    findall() does not, and we use Match objects in fathom-extract.
+    findall() does not, and we use Match objects in ``fathom extract``.
     """
     return list(BASE64_DATA_PATTERN.finditer(from_string))
 

--- a/cli/fathom_web/test/test_list.py
+++ b/cli/fathom_web/test/test_list.py
@@ -1,6 +1,6 @@
 from click.testing import CliRunner
 
-from ..commands.list import main as list_main
+from ..commands.list import list as list_main
 
 
 def test_end_to_end(tmp_path):
@@ -15,7 +15,7 @@ def test_end_to_end(tmp_path):
     # Make the out_file we will save the output to
     out_file = (base_dir / 'out_file.txt')
 
-    # Run fathom-list
+    # Run fathom list
     result = CliRunner().invoke(
         list_main,
         [
@@ -39,7 +39,7 @@ def test_end_to_end(tmp_path):
 
 
 def make_directories(tmp_path):
-    """Makes the directories used as base_dir and in_directory in our fathom-list calls"""
+    """Makes the directories used as base_dir and in_directory in our fathom list calls"""
     base_dir = tmp_path / 'base_dir'
     base_dir.mkdir()
     in_directory = base_dir / 'in_directory'
@@ -48,7 +48,7 @@ def make_directories(tmp_path):
 
 
 def make_html_files(in_directory):
-    """Makes four HTML files in a common directory structure for using in our fathom-list calls"""
+    """Makes four HTML files in a common directory structure for using in our fathom list calls"""
     (in_directory / 'source_a').mkdir()
     a1 = (in_directory / 'source_a' / '1.html')
     a1.touch()
@@ -70,7 +70,7 @@ def test_no_files_to_list(tmp_path):
     # Make the out_file we will save the output to
     out_file = (in_directory / 'out_file.txt')
 
-    # Run fathom-list
+    # Run fathom list
     result = CliRunner().invoke(
         list_main,
         [
@@ -96,7 +96,7 @@ def test_without_base_dir(tmp_path):
     # Make the out_file we will save the output to
     out_file = (base_dir / 'out_file.txt')
 
-    # Run fathom-list
+    # Run fathom list
     result = CliRunner().invoke(
         list_main,
         [
@@ -119,7 +119,7 @@ def test_without_base_dir(tmp_path):
 
 def test_in_directory_does_not_exist():
     """Test giving an invalid path for in_directory causes an error"""
-    # Run fathom-list
+    # Run fathom list
     result = CliRunner().invoke(
         list_main,
         [
@@ -137,7 +137,7 @@ def test_base_dir_does_not_exist(tmp_path):
     """Test giving an invalid path for base-dir causes an error"""
     _, in_directory = make_directories(tmp_path)
 
-    # Run fathom-list
+    # Run fathom list
     result = CliRunner().invoke(
         list_main,
         [

--- a/cli/fathom_web/test/test_pick.py
+++ b/cli/fathom_web/test/test_pick.py
@@ -1,11 +1,11 @@
 from click.testing import CliRunner
 
-from ..commands.pick import main as pick_main
+from ..commands.pick import pick
 
 
 def test_end_to_end(tmp_path):
     """
-    Given a directory of three files, use ``fathom-pick`` to move two files, and
+    Given a directory of three files, use ``fathom pick`` to move two files, and
     check that the files and their potential resources directories have moved.
     """
     # Make temporary source and destination directories
@@ -27,10 +27,10 @@ def test_end_to_end(tmp_path):
     (source / 'resources' / '2' / '1.png').touch()
     (source / 'resources' / '2' / '2.css').touch()
 
-    # Run fathom-pick to move 2 files from source to destination
+    # Run fathom pick to move 2 files from source to destination
     runner = CliRunner()
     # Arguments to invoke() must be passed as strings (this isn't documented!!!)
-    result = runner.invoke(pick_main, [source.as_posix(), destination.as_posix(), '2'])
+    result = runner.invoke(pick, [source.as_posix(), destination.as_posix(), '2'])
     assert result.exit_code == 0
 
     # Check the correct number of files have moved
@@ -74,10 +74,10 @@ def test_resource_directory_path_collision(tmp_path):
     # Add a resource directory for the same file in the destination directory
     (destination / 'resources' / '1').mkdir(parents=True)
 
-    # Run fathom-pick to move the only file from source to destination
+    # Run fathom pick to move the only file from source to destination
     runner = CliRunner()
     # Arguments to invoke() must be passed as strings (this isn't documented!!!)
-    result = runner.invoke(pick_main, [source.as_posix(), destination.as_posix(), '1'])
+    result = runner.invoke(pick, [source.as_posix(), destination.as_posix(), '1'])
 
     # Assert the program exited with a UsageError and our error message is in the program output
     assert result.exit_code == 2

--- a/cli/fathom_web/test/test_train.py
+++ b/cli/fathom_web/test/test_train.py
@@ -2,7 +2,7 @@ import os
 
 from click.testing import CliRunner
 
-from ..commands.train import exclude_indices, main
+from ..commands.train import exclude_indices, train
 
 
 def test_exclude_indices():
@@ -19,7 +19,7 @@ def test_auto_vectorization_smoke(tmp_path):
 
     runner = CliRunner()
     result = runner.invoke(
-        main,
+        train,
         [
             f'{test_dir}/resources/train/',
             '--ruleset',

--- a/cli/fathom_web/vectorizer.py
+++ b/cli/fathom_web/vectorizer.py
@@ -385,7 +385,7 @@ def serving(samples_directory):
         server.shutdown()
         server.server_close()  # joins threads in ThreadingHTTPServer
     if server.swallowable_error_count:
-        print(style(f'{server.swallowable_error_count} error{"" if server.swallowable_error_count == 1 else "s"} while serving samples. Increase vectorization --delay or use fathom-extract to make smaller HTML files.', fg='red'))
+        print(style(f'{server.swallowable_error_count} error{"" if server.swallowable_error_count == 1 else "s"} while serving samples. Increase vectorization --delay or use `fathom extract` to make smaller HTML files.', fg='red'))
 
 
 @contextmanager

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -26,15 +26,7 @@ setup(
         'https://download.pytorch.org/whl/torch_stable.html'
     ],
     entry_points={'console_scripts': [
-        'fathom-extract = fathom_web.commands.extract:main',
-        'fathom-fox = fathom_web.commands.fox:main',
-        'fathom-histogram = fathom_web.commands.histogram:main',
-        'fathom-label = fathom_web.commands.label:main',
-        'fathom-list = fathom_web.commands.list:main',
-        'fathom-pick = fathom_web.commands.pick:main',
-        'fathom-serve = fathom_web.commands.serve:main',
-        'fathom-test = fathom_web.commands.test:main',
-        'fathom-train = fathom_web.commands.train:main',
+        'fathom = fathom_web.commands:fathom',
     ]},
     package_data={'': ['fathom.zip']},
     classifiers=[

--- a/docs/commands/extract.rst
+++ b/docs/commands/extract.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.extract:main
-   :prog: fathom-extract
+.. click:: fathom_web.commands.extract:extract
+   :prog: fathom extract

--- a/docs/commands/fox.rst
+++ b/docs/commands/fox.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.fox:main
-   :prog: fathom-fox
+.. click:: fathom_web.commands.fox:fox
+   :prog: fathom fox

--- a/docs/commands/histogram.rst
+++ b/docs/commands/histogram.rst
@@ -1,5 +1,5 @@
-.. click:: fathom_web.commands.histogram:main
-   :prog: fathom-histogram
+.. click:: fathom_web.commands.histogram:histogram
+   :prog: fathom histogram
 
 ----
 

--- a/docs/commands/label.rst
+++ b/docs/commands/label.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.label:main
-   :prog: fathom-label
+.. click:: fathom_web.commands.label:label
+   :prog: fathom label

--- a/docs/commands/list.rst
+++ b/docs/commands/list.rst
@@ -2,5 +2,5 @@
 
    This command is rarely needed anymore. As of Fathom 3.4, vectorization happens automatically when you run a command that needs it.
 
-.. click:: fathom_web.commands.list:main
-   :prog: fathom-list
+.. click:: fathom_web.commands.list:list
+   :prog: fathom list

--- a/docs/commands/pick.rst
+++ b/docs/commands/pick.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.pick:main
-   :prog: fathom-pick
+.. click:: fathom_web.commands.pick:pick
+   :prog: fathom pick

--- a/docs/commands/serve.rst
+++ b/docs/commands/serve.rst
@@ -2,5 +2,5 @@
 
    This command is rarely needed anymore. As of Fathom 3.4, vectorization happens automatically when you run a command that needs it.
 
-.. click:: fathom_web.commands.serve:main
-   :prog: fathom-serve
+.. click:: fathom_web.commands.serve:serve
+   :prog: fathom serve

--- a/docs/commands/test.rst
+++ b/docs/commands/test.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.test:main
-   :prog: fathom-test
+.. click:: fathom_web.commands.test:test
+   :prog: fathom test

--- a/docs/commands/train.rst
+++ b/docs/commands/train.rst
@@ -1,2 +1,2 @@
-.. click:: fathom_web.commands.train:main
-   :prog: fathom-train
+.. click:: fathom_web.commands.train:train
+   :prog: fathom train

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -11,9 +11,9 @@ FathomFox
 
 FathomFox is a browser extension used to label web pages. The best way to get it is to first install the commandline tools and then run… ::
 
-    fathom-fox
+    fathom fox
 
-This will launch a built-in copy of FathomFox in a fresh Firefox profile so ad blockers and other customizations don't interfere with the clean capture of labeled pages. (Some ad blockers will make changes to the DOM, like adding style attributes to ad iframes to hide them.) Using the commandline launcher also lets you pass in your own rulesets for debugging with the FathomFox Evaluator. See the ``-r`` option on the :doc:`fathom-fox reference page<commands/fox>`.
+This will launch a built-in copy of FathomFox in a fresh Firefox profile so ad blockers and other customizations don't interfere with the clean capture of labeled pages. (Some ad blockers will make changes to the DOM, like adding style attributes to ad iframes to hide them.) Using the commandline launcher also lets you pass in your own rulesets for debugging with the FathomFox Evaluator. See the ``-r`` option on the :doc:`fathom fox reference page<commands/fox>`.
 
 For more casual use, you can instead `install FathomFox through the web <https://addons.mozilla.org/en-US/firefox/addon/fathomfox/>`_, in which case it will be your responsibility to avoid addons that might mutate the DOM.
 

--- a/docs/ruleset.rst
+++ b/docs/ruleset.rst
@@ -15,7 +15,7 @@ The top-level Fathom object is the ruleset, an unordered collection of rules. Th
 Then you call :func:`Ruleset.against` to get back a :class:`BoundRuleset`, which is specific to a given DOM tree. From that, you pull answers.
 
 .. autoclass:: BoundRuleset
-   :members: get
+   :members: get, setCoeffsAndBiases
 
 Rules
 =====

--- a/docs/samples.rst
+++ b/docs/samples.rst
@@ -59,12 +59,12 @@ With a first draft of your rubric written, you're ready to collect samples using
 Storing Samples in Git
 ======================
 
-There are great advantages to storing samples in version control. However, corpora often bump up against the limits imposed by git hosting services like GitHub. Thus, we recommend using `Git Large File Storage (LFS) <https://git-lfs.github.com/>`_ to store samples. This is facilitated by a tool called :doc:`fathom-extract<commands/extract>`, which breaks large subresources like images back out of the HTML. As a bonus, your HTML files will shrink drastically and become feasible to diff and load into text editors.
+There are great advantages to storing samples in version control. However, corpora often bump up against the limits imposed by git hosting services like GitHub. Thus, we recommend using `Git Large File Storage (LFS) <https://git-lfs.github.com/>`_ to store samples. This is facilitated by :doc:`fathom extract<commands/extract>`, which breaks large subresources like images back out of the HTML. As a bonus, your HTML files will shrink drastically and become feasible to diff and load into text editors.
 
-Using fathom-extract
+Using fathom extract
 --------------------
 
-:doc:`fathom-extract<commands/extract>` pulls the inlined data URLs representing subresources (like images and CSS) out of your samples, converts them into images and CSS files, places them in a newly created sample-specific directory within a newly created resources directory, and replaces the data URLs with references to the new files. This let you use Git-LFS to store the new subresource files.
+:doc:`fathom extract<commands/extract>` pulls the inlined data URLs representing subresources (like images and CSS) out of your samples, converts them into images and CSS files, places them in a newly created sample-specific directory within a newly created resources directory, and replaces the data URLs with references to the new files. This let you use Git-LFS to store the new subresource files.
 
 For example, if you have this directory of samples: ::
 
@@ -77,7 +77,7 @@ For example, if you have this directory of samples: ::
 
 Running... ::
 
-    fathom-extract samples/unused
+    fathom extract samples/unused
 
 will change your directory to: ::
 
@@ -120,20 +120,20 @@ The first ``/**`` ensures all sample directories (``unused``, ``training``, etc.
 Training, Testing, and Validation Sets
 ======================================
 
-Up to now, we've kept the samples in the ``unused`` folder. Now it's time to divide them among the training, validation, and testing sets using :doc:`fathom-pick<commands/pick>`. This command randomly moves a given number of files from one directory to another to keep the sets mutually representative.
+Up to now, we've kept the samples in the ``unused`` folder. Now it's time to divide them among the training, validation, and testing sets using :doc:`fathom pick<commands/pick>`. This command randomly moves a given number of files from one directory to another to keep the sets mutually representative.
 
 A training set on the order of a few hundred samples is generally sufficient to push precision and recall percentages into the high 90s. You'll want additional samples for a validation set (to let the trainer know when it's begun to overfit) and a test set (to come up with final accuracy numbers). We recommend a 60/20/20 split among training/validation/testing sets. This gives you large enough validation and testing sets, at typical corpus sizes, while shunting as many samples as possible to the training set so you can mine them for rule ideas.
 
 For example, if you had collected 100 samples initially, you would run these commands to divide them into sets::
 
     cd samples
-    fathom-pick unused training 60
-    fathom-pick unused validation 20
-    fathom-pick unused testing 20
+    fathom pick unused training 60
+    fathom pick unused validation 20
+    fathom pick unused testing 20
 
 If you collected a great many samples, leave some in the ``unused`` folder for now; the trainer will run faster with less data. Work on your ruleset until you have high accuracy on a few dozen samples, and only then add more.
 
 Maintaining Representativeness
 ------------------------------
 
-It's important to keep your sets mutually representative. If you have a collection of samples sorted by some metric, like site popularity or when they were collected, don't use samples 1-100 for training and then 101-200 for validation. Instead, use :command:`fathom-pick` to proportionally assign them to sets: 60% to training and 20% to each of validation and testing. You can repeat this as you later come to need more samples.
+It's important to keep your sets mutually representative. If you have a collection of samples sorted by some metric, like site popularity or when they were collected, don't use samples 1-100 for training and then 101-200 for validation. Instead, use :command:`fathom pick` to proportionally assign them to sets: 60% to training and 20% to each of validation and testing. You can repeat this as you later come to need more samples.

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -12,13 +12,13 @@ Running the Trainer
 
 .. note::
 
-   Fathom has had several trainers over its evolution. Both the Corpus Framework and the trainer built into old versions of FathomFox are obsoleted by :doc:`fathom-train<commands/train>`, described herein.
+   Fathom has had several trainers over its evolution. Both the Corpus Framework and the trainer built into old versions of FathomFox are obsoleted by :doc:`fathom train<commands/train>`, described herein.
 
 Once your samples are collected and at least several rules are written, you're ready to do some initial training. Training is done for one type at a time. If you have types that depend on other types (an advanced case), train the other types first.
 
 Run the trainer. A simple beginning, using just a training set, is... ::
 
-    fathom-train samples/training --ruleset rulesets.js --trainee yourTraineeId
+    fathom train samples/training --ruleset rulesets.js --trainee yourTraineeId
 
 ...yielding something like... ::
 
@@ -50,7 +50,7 @@ Run the trainer. A simple beginning, using just a training set, is... ::
 
 Viewing the TensorBoard graphs with ``tensorboard --logdir runs/`` will quickly show you whether the loss function is oscillating. If you see oscilloscope-like wiggles rather than a smooth descent, the learning rate is too high: the trainer is taking steps that are too big and overshooting the optimum it's chasing. Decrease the learning rate by a factor of 10 until the graph becomes monotonically decreasing::
 
-    fathom-train samples/training  --ruleset rulesets.js --trainee yourTraineeId --learning-rate 0.1 -c tryingToRemoveOscillations
+    fathom train samples/training  --ruleset rulesets.js --trainee yourTraineeId --learning-rate 0.1 -c tryingToRemoveOscillations
 
 Comments (with ``-c``) are your friend, as a heap of anonymous TensorBoard runs otherwise quickly becomes indistinguishable.
 
@@ -62,11 +62,11 @@ Comments (with ``-c``) are your friend, as a heap of anonymous TensorBoard runs 
 
 Once you've tamped down oscillations, use validation samples and early stopping (on by default) to keep Fathom from overfitting::
 
-    fathom-train samples/training --ruleset rulesets.js --trainee yourTraineeId --validation-set samples/validaton
+    fathom train samples/training --ruleset rulesets.js --trainee yourTraineeId --validation-set samples/validaton
 
 The trainer comes with a variety of adjustment knobs to ensure a good fit and to trade off between false positives and false negatives. For a full tour of its capabilities, see...
 
-:doc:`fathom-train reference documentation<commands/train>`
+:doc:`fathom train reference documentation<commands/train>`
 
 Workflow
 ========
@@ -78,7 +78,7 @@ A sane authoring process is a feedback loop something like this:
 #. Run the trainer. Start with 10-20 training pages and an equal number of validation ones.
 #. If accuracy is insufficient, examine the failing training pages. The trainer will point these out on the commandline, but FathomFox's Evaluator will help you track down ones that are hard to distinguish from their tag excerpts. Remediate by changing or adding rules. If there are smells Fathom is missing—positive or negative—add rules that score based on them.
 #. Go back to step 3.
-#. Once *validation accuracy* is sufficient, use the :doc:`fathom-test<commands/test>` tool on a fresh set of *testing* samples. This is your *testing accuracy* and should reflect real-world performance, assuming your sample size is large and representative enough. The computed 95% confidence intervals should help you decide the former.
+#. Once *validation accuracy* is sufficient, use :doc:`fathom test<commands/test>` on a fresh set of *testing* samples. This is your *testing accuracy* and should reflect real-world performance, assuming your sample size is large and representative enough. The computed 95% confidence intervals should help you decide the former.
 #. If testing accuracy is too low, imbibe the testing pages into your training set, and go back to step 3. As typical in supervised learning systems, testing samples should be considered "burned" once they are measured against a single time, as otherwise you are effectively training against them. Samples are precious.
 #. If testing accuracy is sufficient, you're done! Make sure the latest ruleset and coefficients are in your finished product, and ship it.
 
@@ -90,9 +90,9 @@ Setting Breakpoints
 
 If the trainer reports JavaScript errors, you've probably got a bug in your ruleset code. If you can't find it by examination and need to place a breakpoint, the tool of choice is the FathomFox Evaluator.
 
-#. Run :doc:`fathom-fox<commands/fox>`, and pass it your ruleset::
+#. Run :doc:`fathom fox<commands/fox>`, and pass it your ruleset::
 
-    fathom-fox -r rulesets.js
+    fathom fox -r rulesets.js
 
 #. Use the instance of Firefox that comes up to open a page that you think will reproduce the problem.
 #. Show the dev tools, and navigate to the Debugger panel.
@@ -114,6 +114,6 @@ The Evaluator can also point out misrecognized elements, in case the tag exerpts
 Histograms
 ----------
 
-Finally, a great way to examine the scores your rules are emitting is :doc:`fathom-histogram<commands/histogram>`. It can show you how useful a discriminator a rule is and help you notice when the distribution of output values is not what you expect.
+Finally, a great way to examine the scores your rules are emitting is :doc:`fathom histogram<commands/histogram>`. It can show you how useful a discriminator a rule is and help you notice when the distribution of output values is not what you expect.
 
 .. image:: img/histogram.png

--- a/docs/zoo.rst
+++ b/docs/zoo.rst
@@ -10,7 +10,7 @@ Welcome to the Fathom Ruleset Zoo, a bestiary of Fathom real-world examples. Eac
 New-Password Forms
 ==================
 
-Firefox's password manager needed a way to identify new-password fields so it could suggest (and memorize) high-entropy passwords for them. There is standardized markup for this, but only 2-4% of sites use it. Fathom thus stepped in to backstop the other 97%. On a corpus of 508 pages, we trained to a testing precision of 99.2% and recall of 92.1%. (We used ``fathom-train --pos-weight`` to slant the results in favor of fewer false positives, sacrificing some recall for it.) Independent QA work showed an accuracy and false-negative rate better than that of Google Chrome—and a false-positive rate only 1% worse—and all of that with a purely client-side model. It shipped in Firefox 76.
+Firefox's password manager needed a way to identify new-password fields so it could suggest (and memorize) high-entropy passwords for them. There is standardized markup for this, but only 2-4% of sites use it. Fathom thus stepped in to backstop the other 97%. On a corpus of 508 pages, we trained to a testing precision of 99.2% and recall of 92.1%. (We used ``fathom train --pos-weight`` to slant the results in favor of fewer false positives, sacrificing some recall for it.) Independent QA work showed an accuracy and false-negative rate better than that of Google Chrome—and a false-positive rate only 1% worse—and all of that with a purely client-side model. It shipped in Firefox 76.
 
 `New-password ruleset source <https://github.com/mozilla-services/fathom-login-forms/blob/master/new-password/rulesets.js>`_
 

--- a/fathom_fox/README.md
+++ b/fathom_fox/README.md
@@ -4,7 +4,7 @@ A suite of tools for developing [Fathom](https://mozilla.github.io/fathom/) rule
 
 * [Corpus collection and labeling tools](https://mozilla.github.io/fathom/samples.html) (which are likely all you will need)
 * An Evaluator which can help you [drop into the JS debugger](https://mozilla.github.io/fathom/training.html#setting-breakpoints) inside your ruleset
-* A Vectorizer, which you can ignore. (It persists, for now, as an optional manual alternative to simply letting `fathom-train` and other tools take care of vectorization automatically.)
+* A Vectorizer, which you can ignore. (It persists, for now, as an optional manual alternative to simply letting `fathom train` and other tools take care of vectorization automatically.)
 
 For most use cases, it's better to run FathomFox from the commandline rather than installing it through the web. See [Fathom's installation page](https://mozilla.github.io/fathom/installing.html) for instructions.
 

--- a/fathom_fox/addon/pages/vector.html
+++ b/fathom_fox/addon/pages/vector.html
@@ -36,7 +36,7 @@
       No rulesets found. Please download a source checkout of FathomFox, and define one in rulesets.js.
     </p>
     <p>
-      This turns a series of frozen, labeled pages into feature vectors for use with <code>fathom-train</code>. The feature vectors land in a file in your usual downloads folder. Because web extensions aren't allowed to load <code>file://</code> URLs, you might find it necessary to run a local web server like <code>fathom-serve</code> in the directory where your local samples live. <code>fathom-list</code> can help you get a list of filenames to paste here.
+      This turns a series of frozen, labeled pages into feature vectors for use with <code>fathom train</code>. The feature vectors land in a file in your usual downloads folder. Because web extensions aren't allowed to load <code>file://</code> URLs, you might find it necessary to run a local web server like <code>fathom serve</code> in the directory where your local samples live. <code>fathom list</code> can help you get a list of filenames to paste here.
     </p>
     <div class="label">
       <label for="ruleset">Ruleset:</label>

--- a/fathom_fox/src/rulesets.js
+++ b/fathom_fox/src/rulesets.js
@@ -26,10 +26,10 @@ trainees.set(
     // are evaluating, if you are using the FathomFox Evaluator:
     'overlay',
 
-    // Here we paste in coefficients from fathom-train. This lets us use the
-    // Evaluator to see what Fathom is getting wrong. Otherwise, these numbers
-    // do nothing until you deploy your application, so there's no need to
-    // maintain them until then.
+    // Here we paste in coefficients from ``fathom train``. This lets us use
+    // the Evaluator to see what Fathom is getting wrong. Otherwise, these
+    // numbers do nothing until you deploy your application, so there's no need
+    // to maintain them until then.
     {coeffs: new Map([  // [rule name, coefficient]
         ['big', 50.4946],
         ['nearlyOpaque', 48.6396],


### PR DESCRIPTION
Shorten the first line of each subcommand's docstring, because click insists on truncating these in `fathom --help`. Tweak the rest of the docstrings so they don't become awkwardly redundant.