### PR TITLE
Cast ints to floats in MCC computation to avoid potential integer overflows

### DIFF
--- a/cli/fathom_web/accuracy.py
+++ b/cli/fathom_web/accuracy.py
@@ -196,7 +196,7 @@ def pretty_accuracy(description, accuracy, number_of_samples, false_positives, f
         precision = true_positives / (true_positives + false_positives)
     # Recall is the same as the true positive rate:
     recall = 1 - false_negative_rate
-    mcc_denom = sqrt((true_positives + false_positives) * (true_positives + false_negatives) * (true_negatives + false_positives) * (true_negatives + false_negatives))
+    mcc_denom = sqrt(float(true_positives + false_positives) * float(true_positives + false_negatives) * float(true_negatives + false_positives) * float(true_negatives + false_negatives))
     if mcc_denom:
         mcc = (true_positives * true_negatives - false_positives * false_negatives) / mcc_denom
     else:

--- a/cli/fathom_web/accuracy.py
+++ b/cli/fathom_web/accuracy.py
@@ -30,7 +30,7 @@ def accuracy_per_tag(y, y_pred, cutoff, num_prunes):
         false_positives = (predicted_positives & (y == 0)).sum()
         number_of_tags = len(y) + num_prunes
         false_negatives = number_of_tags - successes - false_positives + num_prunes
-        return (successes / number_of_tags), false_positives, false_negatives
+        return (successes / number_of_tags), int(false_positives), int(false_negatives)
 
 
 def per_tag_metrics(page, model, cutoff):
@@ -196,7 +196,7 @@ def pretty_accuracy(description, accuracy, number_of_samples, false_positives, f
         precision = true_positives / (true_positives + false_positives)
     # Recall is the same as the true positive rate:
     recall = 1 - false_negative_rate
-    mcc_denom = sqrt(float(true_positives + false_positives) * float(true_positives + false_negatives) * float(true_negatives + false_positives) * float(true_negatives + false_negatives))
+    mcc_denom = sqrt((true_positives + false_positives) * (true_positives + false_negatives) * (true_negatives + false_positives) * (true_negatives + false_negatives))
     if mcc_denom:
         mcc = (true_positives * true_negatives - false_positives * false_negatives) / mcc_denom
     else:


### PR DESCRIPTION
Casting objects feels bad to me. I think it's because I assume it points to some other problem, but this also seems a simple way to avoid the potential problem.