### PR TITLE
Fix counting errors in metrics due to double counting pruned elements.

### DIFF
--- a/cli/fathom_web/accuracy.py
+++ b/cli/fathom_web/accuracy.py
@@ -29,7 +29,7 @@ def accuracy_per_tag(y, y_pred, cutoff, num_prunes):
         successes = (predicted_positives == y).sum()
         false_positives = (predicted_positives & (y == 0)).sum()
         number_of_tags = len(y) + num_prunes
-        false_negatives = number_of_tags - successes - false_positives + num_prunes
+        false_negatives = number_of_tags - successes - false_positives
         return (successes / number_of_tags), int(false_positives), int(false_negatives)
 
 

--- a/cli/fathom_web/commands/train.py
+++ b/cli/fathom_web/commands/train.py
@@ -272,7 +272,7 @@ def train(training_set, validation_set, ruleset, trainee, training_cache, valida
                           num_samples,
                           false_positives,
                           false_negatives,
-                          num_yes + num_prunes))
+                          num_yes))
     if validation_set:
         accuracy, false_positives, false_negatives = accuracy_per_tag(validation_outs, model(validation_ins), confidence_threshold, validation_prunes)
         print(pretty_accuracy('Validation',
@@ -280,7 +280,7 @@ def train(training_set, validation_set, ruleset, trainee, training_cache, valida
                               len(validation_ins),
                               false_positives,
                               false_negatives,
-                              validation_yes + validation_prunes))
+                              validation_yes))
 
     # Print timing information:
     if training_pages and 'time' in training_pages[0]:


### PR DESCRIPTION
These counting errors regarding pruned elements caused incorrect metrics. In `accuracy.py`, `num_prunes` gets double counted for `false_negatives` since it is already added to `number_of_tags` on the previous line. In the calls to `pretty_accuracy()` in `train.py`, `num_yes` already has the number of pruned elements added to it in `tensors_from()`, so we should not add `num_prunes` to it in the function call.