### PR TITLE
Fixing duplicated vectors in a post-processing step.

### DIFF
--- a/cli/fathom_web/vectorizer.py
+++ b/cli/fathom_web/vectorizer.py
@@ -6,7 +6,6 @@ from json import dump, JSONDecodeError, load
 import hashlib
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 from importlib.resources import open_binary
-from itertools import filterfalse
 import os
 from os import devnull, kill, makedirs
 from os.path import expanduser, expandvars

--- a/cli/fathom_web/vectorizer.py
+++ b/cli/fathom_web/vectorizer.py
@@ -69,8 +69,6 @@ def make_or_find_vectors(ruleset, trainee, sample_set, sample_cache, show_browse
             with sample_cache.open(encoding='utf-8') as file:
                 json = load(file)
             json['header'].update(updated_hashes)
-            # TODO: Solve this problem for real and remove this method
-            remove_duplicate_sample_vectors(json)
             with sample_cache.open('w', encoding='utf-8') as file:
                 dump(json, file, separators=(',', ':'))
             return json
@@ -633,27 +631,6 @@ def unlink_if_exists(path):
         path.unlink()
     except FileNotFoundError:
         pass
-
-
-def remove_duplicate_sample_vectors(json):
-    """Remove potential duplicated feature vectors from the vector file.
-
-    7/21/2020: This is a bandage solution to the problem of duplicated feature
-    vectors. I (Daniel) will fix the source of the problem in ~2-4 weeks. If
-    you are reading this message after that time has passed, please tell me
-    to fix the problem and get rid of this method.
-
-    """
-    filenames_seen = set()
-
-    def not_seen(feature_vector):
-        filename = feature_vector['filename']
-        if filename not in filenames_seen:
-            filenames_seen.add(filename)
-            return False
-        return True
-
-    json['pages'][:] = filterfalse(not_seen, json['pages'])
 
 
 def run(*args, cwd, desc):

--- a/fathom_fox/addon/vector.js
+++ b/fathom_fox/addon/vector.js
@@ -137,6 +137,16 @@ class Vectorizer extends PageVisitor {
     }
 
     async processAtEndOfRun() {
+        // Remove potential duplicated feature vectors from the vector file.
+        // 7/24/2020: This is a bandage solution to the problem of duplicated
+        // feature vectors. I (Daniel) will fix the source of the problem in
+        // ~2-4 weeks. If you are reading this message after that time has
+        // passed, please tell me to fix the problem and get rid of this code.
+        let filenamesSeen = new Set();
+        this.vectors = this.vectors.filter(item => {
+            return filenamesSeen.has(item['filename']) ? false : filenamesSeen.add(item['filename']);
+        });
+
         function compareByKey(key) {
             function cmp(a, b) {
                 const keyA = key(a);

--- a/fathom_fox/addon/vector.js
+++ b/fathom_fox/addon/vector.js
@@ -142,10 +142,8 @@ class Vectorizer extends PageVisitor {
         // feature vectors. I (Daniel) will fix the source of the problem in
         // ~2-4 weeks. If you are reading this message after that time has
         // passed, please tell me to fix the problem and get rid of this code.
-        let filenamesSeen = new Set();
-        this.vectors = this.vectors.filter(item => {
-            return filenamesSeen.has(item['filename']) ? false : filenamesSeen.add(item['filename']);
-        });
+        const filenamesSeen = new Set();
+        this.vectors = this.vectors.filter(item => filenamesSeen.has(item['filename']) ? false : filenamesSeen.add(item['filename']));
 
         function compareByKey(key) {
             function cmp(a, b) {


### PR DESCRIPTION
This is a bandage solution for #256. Any duplicated feature vectors get removed at the same time that the file hashes are added to the header after vectorization. Any qualms with this being an in-place operation? As I stated in the linked issue, I will solve the problem more appropriately after the initial form autofill effort is completed.