### PR TITLE
Support bundling fathom as an ES module file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /fathom/README.md
 /fathom/**/*.js
 !/fathom/rollup.config.js
+!/fathom/rollupESModule.config.js
 !/fathom/test/browser/*
 /fathom_fox/node_modules
 /fathom_fox/addon/contentScript.js

--- a/fathom/Makefile
+++ b/fathom/Makefile
@@ -33,6 +33,8 @@ publish: $(JS)
 
 bundle: dist/fathom.js
 
+bundleESModule: dist/fathom.mjs
+
 # .npm_installed is an empty file we touch whenever we run npm install. This
 # target redoes the install if package.json is newer than that file:
 .npm_installed: package.json
@@ -47,6 +49,9 @@ clean:
 
 dist/fathom.js: rollup.config.js .npm_installed $(MJS)
 	@node_modules/.bin/rollup -c
+
+dist/fathom.mjs: rollupESModule.config.js .npm_installed $(MJS)
+	@node_modules/.bin/rollup -c rollupESModule.config.js
 
 
 .PHONY: js lint test coveralls debugtest publish bundle clean

--- a/fathom/rollupESModule.config.js
+++ b/fathom/rollupESModule.config.js
@@ -1,0 +1,12 @@
+// Bundle all of Fathom into a single file for use inside web extensions or
+// other applications. If possible, use ES6-style import statements in your
+// code instead, and let rollup pull in just what Fathom code is necessary. See
+// /fathom_fox/rollup.config.js for an example.
+export default {
+  input: 'index.mjs',
+  output: {
+    file: 'dist/fathom.mjs',
+    format: 'esm',
+    name: 'fathom',
+  }
+};


### PR DESCRIPTION
Firefox desktop uses the exported bundle, and we are currently moving to ES modules, therefore we'd like to create a target where we can have an ES module export as well.